### PR TITLE
fix: resolve poses with tree relations and constraints together

### DIFF
--- a/spec/utils/constraints/index.spec.ts
+++ b/spec/utils/constraints/index.spec.ts
@@ -37,9 +37,7 @@ describe('src/utils/constraints/index.ts', () => {
         }),
         getBone({
           id: 'b',
-          constraints: [
-            getConstraintByName('IK', ik.getOption({ targetId: 'a' })),
-          ],
+          parentId: 'a',
         }),
         getBone({ id: 'c' }),
       ]

--- a/spec/utils/poseResolver.spec.ts
+++ b/spec/utils/poseResolver.spec.ts
@@ -163,7 +163,8 @@ describe('utils/poseResolver.ts', () => {
       ],
     }
     const boneMap = {
-      bone_a: getBone({ id: 'bone_a' }),
+      bone_a: getBone({ id: 'bone_a', parentId: 'bone_b' }),
+      bone_b: getBone({ id: 'bone_b' }),
     }
     const elementMap = {
       elm_a: getBElement({ id: 'elm_a', boneId: 'bone_a' }),

--- a/src/App.vue
+++ b/src/App.vue
@@ -116,7 +116,6 @@ import { useHistoryStore } from './store/history'
 import { useAnimationStore } from './store/animation'
 import { useStrage } from './composables/strage'
 import { useElementStore } from './store/element'
-import { applyAllConstraints } from './utils/constraints'
 
 export default defineComponent({
   components: {
@@ -153,7 +152,7 @@ export default defineComponent({
     const posedMap = computed(() => {
       if (!lastSelectedArmature.value) return {}
 
-      const posedMap = getTransformedBoneMap(
+      return getTransformedBoneMap(
         toMap(
           lastSelectedArmature.value.bones.map((b) => {
             return {
@@ -166,7 +165,6 @@ export default defineComponent({
           })
         )
       )
-      return applyAllConstraints(posedMap)
     })
 
     const visibledBoneMap = computed(() => {

--- a/src/components/elements/ElementLayer.vue
+++ b/src/components/elements/ElementLayer.vue
@@ -40,7 +40,6 @@ import {
   getTransformedBoneMap,
 } from '/@/utils/armatures'
 import { getPosedElementTree } from '/@/utils/poseResolver'
-import { applyAllConstraints } from '/@/utils/constraints'
 
 function getId(elm: ElementNode | string): string {
   if (typeof elm === 'string') return elm
@@ -71,19 +70,17 @@ export default defineComponent({
       )
       if (!armature) return {}
 
-      return applyAllConstraints(
-        getTransformedBoneMap(
-          toMap(
-            armature.bones.map((b) => {
-              return {
-                ...b,
-                transform: convolutePoseTransforms([
-                  animationStore.getCurrentSelfTransforms(b.id),
-                  canvasStore.getEditPoseTransforms(b.id),
-                ]),
-              }
-            })
-          )
+      return getTransformedBoneMap(
+        toMap(
+          armature.bones.map((b) => {
+            return {
+              ...b,
+              transform: convolutePoseTransforms([
+                animationStore.getCurrentSelfTransforms(b.id),
+                canvasStore.getEditPoseTransforms(b.id),
+              ]),
+            }
+          })
         )
       )
     })

--- a/src/store/animation.ts
+++ b/src/store/animation.ts
@@ -164,10 +164,7 @@ const selectedAllBones = computed(() => {
 })
 
 const selectedBones = computed(() => {
-  return getPoseSelectedBones(
-    currentPosedBones.value,
-    store.state.selectedBones
-  )
+  return getPoseSelectedBones(store.boneMap.value, store.state.selectedBones)
 })
 
 const selectedPosedBoneOrigin = computed(
@@ -206,7 +203,7 @@ function pastePoses(mapByBoneId: IdMap<Transform>) {
       ...mapReduce(
         dropMapIfFalse(mapByBoneId, (_, boneId) => {
           // drop poses of unexisted bones
-          return !!currentPosedBones.value[boneId]
+          return !!store.boneMap.value[boneId]
         }),
         (t, boneId) => {
           // invert keyframe's pose & paste the pose

--- a/src/utils/poseResolver.ts
+++ b/src/utils/poseResolver.ts
@@ -32,12 +32,12 @@ import {
   ElementNode,
   IdMap,
   Transform,
+  getTransform,
 } from '../models'
 import { getInterpolatedTransformMapByBoneId } from './animations'
 import { getTransformedBoneMap, poseToAffine } from './armatures'
 import { mapReduce } from './commons'
 import { getTnansformStr } from './helpers'
-import { applyAllConstraints } from '/@/utils/constraints'
 
 export type TransformCache = {
   [relativeRootBoneId: string]: { [boneId: string]: Transform }
@@ -199,13 +199,14 @@ export function bakeKeyframe(
   svgRoot: ElementNode,
   currentFrame: number
 ): IdMap<AffineMatrix> {
-  const interpolatedBoneMap = mapReduce(
-    getInterpolatedTransformMapByBoneId(keyframeMapByBoneId, currentFrame),
-    (transform, id) => ({ ...boneMap[id], transform })
+  const interpolatedTransformMap = getInterpolatedTransformMapByBoneId(
+    keyframeMapByBoneId,
+    currentFrame
   )
-  const resolvedBoneMap = applyAllConstraints(
-    getTransformedBoneMap(interpolatedBoneMap)
-  )
-
+  const interpolatedBoneMap = mapReduce(boneMap, (bone, id) => ({
+    ...bone,
+    transform: interpolatedTransformMap[id] ?? getTransform(),
+  }))
+  const resolvedBoneMap = getTransformedBoneMap(interpolatedBoneMap)
   return getPosedElementMatrixMap(resolvedBoneMap, elementMap, svgRoot)
 }


### PR DESCRIPTION
- treat tree relations as same as constraints and sort bones to resolve poses by high depedency
- a pose of parent must be resolved earlier than the child one
tree relations cannot be circular
- constraints cannot be resolved perfectlly
they may be circular