### PR TITLE
perf: use throttle to reduce mousemove event callings

### DIFF
--- a/spec/composables/throttle.spec.ts
+++ b/spec/composables/throttle.spec.ts
@@ -1,0 +1,79 @@
+/*
+This file is part of Blendic SVG.
+
+Blendic SVG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Blendic SVG is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Blendic SVG.  If not, see <https://www.gnu.org/licenses/>.
+
+Copyright (C) 2021, Tomoya Komiyama.
+*/
+
+import { useThrottle } from '/@/composables/throttle'
+
+async function sleep(time: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, time)
+  })
+}
+
+describe('src/composables/throttle.ts', () => {
+  describe('useThrottle', () => {
+    it('omit internal calling', async () => {
+      const fn = jest.fn()
+      const t = useThrottle(fn, 10)
+      t()
+      t()
+      t()
+      await sleep(20)
+
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+    it('recall after waiting the interval', async () => {
+      const fn = jest.fn()
+      const t = useThrottle(fn, 10)
+      t()
+      await sleep(20)
+      t()
+      await sleep(20)
+
+      expect(fn).toHaveBeenCalledTimes(2)
+    })
+    it('pass args', async () => {
+      const mock = jest.fn()
+      const fn = (val1: number, val2: number) => mock(val1, val2)
+      const t = useThrottle(fn, 10)
+      t(10, 100)
+      await sleep(5)
+      t(20, 200)
+      await sleep(20)
+      expect(mock).toHaveBeenCalledTimes(1)
+      expect(mock).toHaveBeenCalledWith(20, 200)
+    })
+    describe('if option.leading is true', () => {
+      fit('call leading', async () => {
+        const mock = jest.fn()
+        const fn = (val1: number, val2: number) => mock(val1, val2)
+        const t = useThrottle(fn, 10, true)
+        t(10, 100)
+        await sleep(20)
+        t(20, 200)
+        await sleep(5)
+        t(30, 300)
+        await sleep(20)
+
+        expect(mock).toHaveBeenCalledTimes(2)
+        expect(mock).toHaveBeenNthCalledWith(1, 10, 100)
+        expect(mock).toHaveBeenNthCalledWith(2, 20, 200)
+      })
+    })
+  })
+})

--- a/src/components/atoms/HueCiclePicker.vue
+++ b/src/components/atoms/HueCiclePicker.vue
@@ -39,11 +39,12 @@ Copyright (C) 2021, Tomoya Komiyama.
 
 <script lang="ts">
 import { getRadian, IVec2, sub } from 'okageo'
-import { getPagePosition, useDrag } from 'okanvas'
+import { DragArgs, getPagePosition, useDrag } from 'okanvas'
 import { computed, defineComponent, ref } from 'vue'
 import { useGlobalMousemove, useGlobalMouseup } from '/@/composables/window'
 import { getContinuousRadDiff } from '/@/utils/geometry'
 import HueCicle from '/@/components/atoms/HueCicle.vue'
+import { useThrottle } from '/@/composables/throttle'
 
 export default defineComponent({
   components: { HueCicle },
@@ -92,11 +93,14 @@ export default defineComponent({
       return Math.round((rad * 180) / Math.PI)
     }
 
-    const drag = useDrag((arg) => {
+    function onDrag(arg: DragArgs) {
       const h = getHueByPoint(arg.p)
       if (h === undefined) return
       update(h)
-    })
+    }
+    const throttleDrag = useThrottle(onDrag, 1000 / 60, true)
+
+    const drag = useDrag(throttleDrag)
     useGlobalMousemove(drag.onMove)
     useGlobalMouseup(() => {
       drag.onUp()

--- a/src/components/atoms/ResizableH.vue
+++ b/src/components/atoms/ResizableH.vue
@@ -33,8 +33,9 @@ Copyright (C) 2021, Tomoya Komiyama.
 </template>
 
 <script lang="ts">
-import { useDrag } from 'okanvas'
+import { DragArgs, useDrag } from 'okanvas'
 import { computed, defineComponent, nextTick, onMounted, ref } from 'vue'
+import { useThrottle } from '/@/composables/throttle'
 import { useGlobalMousemove, useGlobalMouseup } from '/@/composables/window'
 import { clamp, logRound } from '/@/utils/geometry'
 
@@ -78,7 +79,7 @@ export default defineComponent({
       rightPx.value = right.value?.getBoundingClientRect().width ?? 100
     }
 
-    const drag = useDrag(async (arg) => {
+    async function onDrag(arg: DragArgs) {
       if (!root.value) return
 
       const rootRect = root.value.getBoundingClientRect()
@@ -93,7 +94,10 @@ export default defineComponent({
       await nextTick()
       calcSize()
       window.dispatchEvent(new Event('resize'))
-    })
+    }
+    const throttleDrag = useThrottle(onDrag, 1000 / 60, true)
+
+    const drag = useDrag(throttleDrag)
     useGlobalMousemove((e) => {
       e.preventDefault()
       drag.onMove(e)

--- a/src/components/atoms/ResizableV.vue
+++ b/src/components/atoms/ResizableV.vue
@@ -32,8 +32,9 @@ Copyright (C) 2021, Tomoya Komiyama.
 </template>
 
 <script lang="ts">
-import { useDrag } from 'okanvas'
+import { DragArgs, useDrag } from 'okanvas'
 import { computed, defineComponent, ref, nextTick } from 'vue'
+import { useThrottle } from '/@/composables/throttle'
 import { useGlobalMousemove, useGlobalMouseup } from '/@/composables/window'
 import { clamp, logRound } from '/@/utils/geometry'
 
@@ -65,7 +66,7 @@ export default defineComponent({
       return `calc((100% - ${anchorHeight}px) * ${1 - rate.value})`
     })
 
-    const drag = useDrag(async (arg) => {
+    async function onDrag(arg: DragArgs) {
       if (!root.value) return
 
       const rootRect = root.value.getBoundingClientRect()
@@ -79,7 +80,10 @@ export default defineComponent({
       )
       await nextTick()
       window.dispatchEvent(new Event('resize'))
-    })
+    }
+    const throttleDrag = useThrottle(onDrag, 1000 / 60, true)
+
+    const drag = useDrag(throttleDrag)
     useGlobalMousemove((e) => {
       e.preventDefault()
       drag.onMove(e)

--- a/src/components/atoms/SliderInput.vue
+++ b/src/components/atoms/SliderInput.vue
@@ -39,8 +39,9 @@ Copyright (C) 2021, Tomoya Komiyama.
 </template>
 
 <script lang="ts">
-import { useDrag } from 'okanvas'
+import { DragArgs, useDrag } from 'okanvas'
 import { computed, defineComponent, PropType, ref, watchEffect } from 'vue'
+import { useThrottle } from '/@/composables/throttle'
 import { useGlobalMousemove, useGlobalMouseup } from '/@/composables/window'
 import { clamp, logRound } from '/@/utils/geometry'
 
@@ -117,7 +118,7 @@ export default defineComponent({
       }
     }
 
-    const drag = useDrag((arg) => {
+    function onDrag(arg: DragArgs) {
       if (!el.value) return
       const width = el.value.getBoundingClientRect().width
       if (width === 0) return
@@ -143,7 +144,11 @@ export default defineComponent({
       }
 
       input()
-    })
+    }
+    const throttleDrag = useThrottle(onDrag, 1000 / 60, true)
+
+    const drag = useDrag(throttleDrag)
+
     useGlobalMousemove((e) => {
       e.preventDefault()
       drag.onMove(e)

--- a/src/components/molecules/ColorPicker.vue
+++ b/src/components/molecules/ColorPicker.vue
@@ -60,7 +60,7 @@ Copyright (C) 2021, Tomoya Komiyama.
 
 <script lang="ts">
 import { IVec2, sub } from 'okageo'
-import { getPagePosition, useDrag } from 'okanvas'
+import { DragArgs, getPagePosition, useDrag } from 'okanvas'
 import { computed, defineComponent, PropType, ref } from 'vue'
 import { useGlobalMousemove, useGlobalMouseup } from '/@/composables/window'
 import {
@@ -74,6 +74,7 @@ import { clamp } from '/@/utils/geometry'
 import SliderInput from '/@/components/atoms/SliderInput.vue'
 import InlineField from '/@/components/atoms/InlineField.vue'
 import HueCiclePicker from '/@/components/atoms/HueCiclePicker.vue'
+import { useThrottle } from '/@/composables/throttle'
 
 const RECT_SIZE = 110
 
@@ -144,9 +145,12 @@ export default defineComponent({
       update({ ...localHsva.value, s: sv.s, v: sv.v }, seriesKey.value)
     }
 
-    const drag = useDrag((arg) => {
+    function onDrag(arg: DragArgs) {
       updateByRect(arg.p)
-    })
+    }
+    const throttleDrag = useThrottle(onDrag, 1000 / 60, true)
+
+    const drag = useDrag(throttleDrag)
     useGlobalMousemove(drag.onMove)
     useGlobalMouseup(() => {
       drag.onUp()

--- a/src/composables/throttle.ts
+++ b/src/composables/throttle.ts
@@ -1,0 +1,47 @@
+/*
+This file is part of Blendic SVG.
+
+Blendic SVG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Blendic SVG is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Blendic SVG.  If not, see <https://www.gnu.org/licenses/>.
+
+Copyright (C) 2021, Tomoya Komiyama.
+*/
+
+// if you want to avoid calling async, set leading true
+// e.g. e.currentTarget is lost in async calling
+export function useThrottle<T extends (...args: any[]) => void>(
+  fn: T,
+  interval: number,
+  leading = false
+) {
+  let wait = false
+
+  function throttle(...args: Parameters<T>) {
+    if (wait) return
+
+    wait = true
+
+    if (leading) {
+      fn(...args)
+    }
+
+    setTimeout(() => {
+      if (!leading) {
+        fn(...args)
+      }
+      wait = false
+    }, interval)
+  }
+
+  return throttle
+}


### PR DESCRIPTION
- `e.currentTarget` can be accessed only synchronously
=> use leading throttle