### PR TITLE
Work/filter existed keyframes

### DIFF
--- a/spec/utils/helpers.spec.ts
+++ b/spec/utils/helpers.spec.ts
@@ -18,6 +18,7 @@ Copyright (C) 2021, Tomoya Komiyama.
 */
 
 import { getBone, getTransform } from '/@/models'
+import { getKeyframePoint } from '/@/models/keyframe'
 import { getConstraint } from '/@/utils/constraints'
 import {
   parseStyle,
@@ -138,23 +139,53 @@ describe('utils/helpers.ts', () => {
   })
 
   describe('getKeyframeBoneSummary', () => {
-    it('should return a bone summary', () => {
-      expect(getKeyframeBoneSummary(getBone({ id: 'a', name: 'b' }))).toEqual({
+    it('should return a bone summary with children having keyframes', () => {
+      expect(
+        getKeyframeBoneSummary(getBone({ id: 'a', name: 'b' }), {
+          translateX: getKeyframePoint(),
+          rotate: getKeyframePoint(),
+        })
+      ).toEqual({
         id: 'a',
         name: 'b',
         children: {
           translateX: 0,
-          translateY: 1,
-          rotate: 2,
-          scaleX: 3,
-          scaleY: 4,
+          rotate: 1,
         },
+      })
+    })
+    it('should return a bone summary with empty children if the keyframe does not exist', () => {
+      expect(getKeyframeBoneSummary(getBone({ id: 'a', name: 'b' }))).toEqual({
+        id: 'a',
+        name: 'b',
+        children: {},
       })
     })
   })
 
   describe('getKeyframeConstraintSummary', () => {
-    it('should return a bone summary', () => {
+    it('should return a bone summary with children having keyframes', () => {
+      expect(
+        getKeyframeConstraintSummary(
+          getBone({ id: 'a', name: 'b' }),
+          getConstraint({
+            id: 'aa',
+            name: 'bb',
+            type: 'IK',
+          }),
+          {
+            influence: getKeyframePoint(),
+          }
+        )
+      ).toEqual({
+        id: 'aa',
+        name: 'b:bb',
+        children: {
+          influence: 0,
+        },
+      })
+    })
+    it('should return a bone summary with empty children if the keyframe does not exist', () => {
       expect(
         getKeyframeConstraintSummary(
           getBone({ id: 'a', name: 'b' }),
@@ -167,9 +198,7 @@ describe('utils/helpers.ts', () => {
       ).toEqual({
         id: 'aa',
         name: 'b:bb',
-        children: {
-          influence: 0,
-        },
+        children: {},
       })
     })
   })

--- a/src/components/AnimationPanel.vue
+++ b/src/components/AnimationPanel.vue
@@ -225,6 +225,7 @@ import {
   getTargetTopMap,
   KeyframeTargetSummary,
 } from '/@/utils/helpers'
+import { getKeyframeExistedPropsMap } from '/@/utils/keyframes'
 
 const labelHeight = 24
 
@@ -406,14 +407,23 @@ export default defineComponent({
       selectedAllBoneIdList.value.concat(selectedAllConstraintIdList.value)
     )
     const selectedTargetSummaryList = computed<KeyframeTargetSummary[]>(() => {
+      const keyframeMapByTargetId = animationStore.keyframeMapByTargetId.value
       const boneMap = animationStore.selectedBoneMap.value
       const constraintMap = animationStore.selectedConstraintMap.value
       return [
-        ...selectedAllBoneList.value.map((b) => getKeyframeBoneSummary(b)),
+        ...selectedAllBoneList.value.map((b) =>
+          getKeyframeBoneSummary(
+            b,
+            getKeyframeExistedPropsMap(keyframeMapByTargetId[b.id] ?? []).props
+          )
+        ),
         ...selectedAllConstraintIdList.value.map((id) => {
           const c = constraintMap[id]
-          const b = boneMap[c.boneId]
-          return getKeyframeConstraintSummary(b, c)
+          return getKeyframeConstraintSummary(
+            boneMap[c.boneId],
+            c,
+            getKeyframeExistedPropsMap(keyframeMapByTargetId[id] ?? []).props
+          )
         }),
       ]
     })

--- a/src/store/animation.ts
+++ b/src/store/animation.ts
@@ -772,8 +772,8 @@ function getCompleteDuplicateKeyframesItem(
   updatedKeyframeList: KeyframeBase[]
 ) {
   return convolute(
-    getExecUpdateKeyframeItem(toMap(updatedKeyframeList)),
-    [getExecInsertKeyframeItem(duplicatedKeyframeList, true, true)],
+    getExecInsertKeyframeItem(duplicatedKeyframeList, true, true),
+    [getExecUpdateKeyframeItem(toMap(updatedKeyframeList))],
     'Duplicate Keyframe'
   )
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -139,30 +139,45 @@ export interface KeyframeTargetSummary {
   }
 }
 
-const boneLabelChildren = {
-  translateX: 0,
-  translateY: 1,
-  rotate: 2,
-  scaleX: 3,
-  scaleY: 4,
+const boneLabelChildren = [
+  'translateX',
+  'translateY',
+  'rotate',
+  'scaleX',
+  'scaleY',
+]
+
+function getIndexList(target: IdMap<any>, list: string[]): IdMap<number> {
+  return list
+    .filter((key) => target[key])
+    .reduce<IdMap<number>>((p, key, i) => {
+      p[key] = i
+      return p
+    }, {})
 }
 
-export function getKeyframeBoneSummary(bone: Bone): KeyframeTargetSummary {
+export function getKeyframeBoneSummary(
+  bone: Bone,
+  keyframeProps: { [key: string]: any } = {}
+): KeyframeTargetSummary {
   return {
     id: bone.id,
     name: bone.name,
-    children: boneLabelChildren,
+    children: getIndexList(keyframeProps, boneLabelChildren),
   }
 }
 
+const constraintLabelChildren = ['influence']
+
 export function getKeyframeConstraintSummary(
   bone: Bone,
-  constraint: BoneConstraint
+  constraint: BoneConstraint,
+  keyframeProps: { [key: string]: any } = {}
 ): KeyframeTargetSummary {
   return {
     id: constraint.id,
     name: `${bone.name}:${constraint.name}`,
-    children: { influence: 0 },
+    children: getIndexList(keyframeProps, constraintLabelChildren),
   }
 }
 


### PR DESCRIPTION
### feat: show target labels having some keyframes
![image](https://user-images.githubusercontent.com/20733354/115730216-0dc59400-a3c1-11eb-82f3-12bca5aad27e.png)

### fix: invalid grabbing or duplicating keyframes under particular conditions
conditions
- a keyframe has two more points
- grab or duplicate not of all points and edit only value: move on only axis 'y'
=> the points are reverted unexpectedly