### PR TITLE
fix: Show original SVG correctly

### DIFF
--- a/spec/utils/helpers.spec.ts
+++ b/spec/utils/helpers.spec.ts
@@ -123,17 +123,21 @@ describe('utils/helpers.ts', () => {
   })
 
   describe('normalizeAttributes', () => {
-    it('drop styles duplicated with attributes', () => {
-      expect(
-        normalizeAttributes({
-          style: 'fill:black;opacity:0.1;stroke:black;',
-          fill: 'red',
-          stroke: 'green',
-        })
-      ).toEqual({
-        style: 'opacity:0.1;',
+    it('should override styles including the attributes', () => {
+      const ret = normalizeAttributes({
+        style: 'fill:black;opacity:0.1;stroke:black;',
         fill: 'red',
         stroke: 'green',
+      })
+      expect(ret).toEqual({
+        style: expect.anything(),
+        fill: 'red',
+        stroke: 'green',
+      })
+      expect(parseStyle(ret.style)).toEqual({
+        fill: 'red',
+        stroke: 'green',
+        opacity: '0.1',
       })
     })
   })

--- a/src/components/elements/ElementLayer.vue
+++ b/src/components/elements/ElementLayer.vue
@@ -29,11 +29,13 @@ Copyright (C) 2021, Tomoya Komiyama.
       stroke="#777"
       stroke-dasharray="2 2"
     ></rect>
-    <NativeElement
-      v-for="node in elementRoot.children"
-      :key="getId(node)"
-      :element="node"
-    />
+    <g :id="elementRoot.id">
+      <NativeElement
+        v-for="node in elementRoot.children"
+        :key="getId(node)"
+        :element="node"
+      />
+    </g>
   </g>
 </template>
 

--- a/src/utils/elements.ts
+++ b/src/utils/elements.ts
@@ -58,7 +58,8 @@ function parseElementNode(parentElm: SVGElement): ElementNode {
   return getElementNode(
     {
       id,
-      tag: parentElm.tagName.toLowerCase(),
+      // NOTE: case-sensitive e.g. <foreignObject>
+      tag: parentElm.tagName,
       attributes: Array.from(parentElm.attributes).reduce<{
         [name: string]: string
       }>((p, c) => ({ ...p, [c.name]: c.value }), {}),

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -19,7 +19,6 @@ Copyright (C) 2021, Tomoya Komiyama.
 
 import { IVec2, IRectangle, isZero } from 'okageo'
 import { IdMap, Bone, ElementNodeAttributes, Transform } from '../models/index'
-import { dropMap } from '/@/utils/commons'
 import { BoneConstraint } from '/@/utils/constraints'
 
 function getScaleText(scale: IVec2, origin: IVec2): string {
@@ -116,7 +115,11 @@ export function normalizeAttributes(
 ): ElementNodeAttributes {
   return {
     ...attributes,
-    style: toStyle(dropMap(parseStyle(attributes.style), attributes)),
+    style: toStyle({
+      ...parseStyle(attributes.style),
+      ...(attributes.fill ? { fill: attributes.fill } : {}),
+      ...(attributes.stroke ? { stroke: attributes.stroke } : {}),
+    }),
   }
 }
 


### PR DESCRIPTION
- avoid lower casing tag name => for foreignObject
- add root id to element root to apply original style

fix #173 