### PR TITLE
mousemove with shift key make the cursor slow

### DIFF
--- a/spec/components/atoms/__snapshots__/SliderInput.spec.ts.snap
+++ b/spec/components/atoms/__snapshots__/SliderInput.spec.ts.snap
@@ -14,7 +14,6 @@ exports[`src/components/atoms/SliderInput.vue snapshot default 1`] = `
   <div
     class="slider-forward"
   />
-  <!--v-if-->
 </div>
 `;
 
@@ -30,7 +29,6 @@ exports[`src/components/atoms/SliderInput.vue snapshot disabled 1`] = `
     disabled=""
     type="text"
   />
-  <!--v-if-->
   <!--v-if-->
 </div>
 `;

--- a/spec/components/molecules/constraints/__snapshots__/CopyLocationOptionField.spec.ts.snap
+++ b/spec/components/molecules/constraints/__snapshots__/CopyLocationOptionField.spec.ts.snap
@@ -232,7 +232,6 @@ exports[`/@/src/components/molecules/constraints/CopyLocationOptionField.vue sna
         <div
           class="slider-forward"
         />
-        <!--v-if-->
       </div>
       <button
         type="button"

--- a/spec/components/molecules/constraints/__snapshots__/CopyRotationOptionField.spec.ts.snap
+++ b/spec/components/molecules/constraints/__snapshots__/CopyRotationOptionField.spec.ts.snap
@@ -163,7 +163,6 @@ exports[`/@/src/components/molecules/constraints/CopyRotationOptionField.vue sna
         <div
           class="slider-forward"
         />
-        <!--v-if-->
       </div>
       <button
         type="button"

--- a/spec/components/molecules/constraints/__snapshots__/CopyScaleOptionField.spec.ts.snap
+++ b/spec/components/molecules/constraints/__snapshots__/CopyScaleOptionField.spec.ts.snap
@@ -186,7 +186,6 @@ exports[`/@/src/components/molecules/constraints/CopyScaleOptionField.vue snapsh
         <div
           class="slider-forward"
         />
-        <!--v-if-->
       </div>
       
     </div>
@@ -218,7 +217,6 @@ exports[`/@/src/components/molecules/constraints/CopyScaleOptionField.vue snapsh
         <div
           class="slider-forward"
         />
-        <!--v-if-->
       </div>
       <button
         type="button"

--- a/spec/components/molecules/constraints/__snapshots__/IKOptionField.spec.ts.snap
+++ b/spec/components/molecules/constraints/__snapshots__/IKOptionField.spec.ts.snap
@@ -108,7 +108,6 @@ exports[`/@/src/components/molecules/constraints/IKOptionField.vue snapshot 1`] 
         <div
           class="slider-forward"
         />
-        <!--v-if-->
       </div>
       
     </div>
@@ -140,7 +139,6 @@ exports[`/@/src/components/molecules/constraints/IKOptionField.vue snapshot 1`] 
         <div
           class="slider-forward"
         />
-        <!--v-if-->
       </div>
       
     </div>
@@ -172,7 +170,6 @@ exports[`/@/src/components/molecules/constraints/IKOptionField.vue snapshot 1`] 
         <div
           class="slider-forward"
         />
-        <!--v-if-->
       </div>
       <button
         type="button"

--- a/spec/components/molecules/constraints/__snapshots__/LimitLocationOptionField.spec.ts.snap
+++ b/spec/components/molecules/constraints/__snapshots__/LimitLocationOptionField.spec.ts.snap
@@ -75,7 +75,6 @@ exports[`/@/src/components/molecules/constraints/LimitLocationOptionField.vue sn
           <div
             class="slider-forward"
           />
-          <!--v-if-->
         </div>
       </div>
       
@@ -119,7 +118,6 @@ exports[`/@/src/components/molecules/constraints/LimitLocationOptionField.vue sn
           <div
             class="slider-forward"
           />
-          <!--v-if-->
         </div>
       </div>
       
@@ -163,7 +161,6 @@ exports[`/@/src/components/molecules/constraints/LimitLocationOptionField.vue sn
           <div
             class="slider-forward"
           />
-          <!--v-if-->
         </div>
       </div>
       
@@ -207,7 +204,6 @@ exports[`/@/src/components/molecules/constraints/LimitLocationOptionField.vue sn
           <div
             class="slider-forward"
           />
-          <!--v-if-->
         </div>
       </div>
       
@@ -240,7 +236,6 @@ exports[`/@/src/components/molecules/constraints/LimitLocationOptionField.vue sn
         <div
           class="slider-forward"
         />
-        <!--v-if-->
       </div>
       <button
         type="button"

--- a/spec/components/molecules/constraints/__snapshots__/LimitRotationOptionField.spec.ts.snap
+++ b/spec/components/molecules/constraints/__snapshots__/LimitRotationOptionField.spec.ts.snap
@@ -75,7 +75,6 @@ exports[`/@/src/components/molecules/constraints/LimitRotationOptionField.vue sn
           <div
             class="slider-forward"
           />
-          <!--v-if-->
         </div>
       </div>
       
@@ -119,7 +118,6 @@ exports[`/@/src/components/molecules/constraints/LimitRotationOptionField.vue sn
           <div
             class="slider-forward"
           />
-          <!--v-if-->
         </div>
       </div>
       
@@ -152,7 +150,6 @@ exports[`/@/src/components/molecules/constraints/LimitRotationOptionField.vue sn
         <div
           class="slider-forward"
         />
-        <!--v-if-->
       </div>
       <button
         type="button"

--- a/spec/components/molecules/constraints/__snapshots__/LimitScaleOptionField.spec.ts.snap
+++ b/spec/components/molecules/constraints/__snapshots__/LimitScaleOptionField.spec.ts.snap
@@ -75,7 +75,6 @@ exports[`/@/src/components/molecules/constraints/LimitScaleOptionField.vue snaps
           <div
             class="slider-forward"
           />
-          <!--v-if-->
         </div>
       </div>
       
@@ -119,7 +118,6 @@ exports[`/@/src/components/molecules/constraints/LimitScaleOptionField.vue snaps
           <div
             class="slider-forward"
           />
-          <!--v-if-->
         </div>
       </div>
       
@@ -163,7 +161,6 @@ exports[`/@/src/components/molecules/constraints/LimitScaleOptionField.vue snaps
           <div
             class="slider-forward"
           />
-          <!--v-if-->
         </div>
       </div>
       
@@ -207,7 +204,6 @@ exports[`/@/src/components/molecules/constraints/LimitScaleOptionField.vue snaps
           <div
             class="slider-forward"
           />
-          <!--v-if-->
         </div>
       </div>
       
@@ -240,7 +236,6 @@ exports[`/@/src/components/molecules/constraints/LimitScaleOptionField.vue snaps
         <div
           class="slider-forward"
         />
-        <!--v-if-->
       </div>
       <button
         type="button"

--- a/spec/components/panelContents/__snapshots__/ConstraintList.spec.ts.snap
+++ b/spec/components/panelContents/__snapshots__/ConstraintList.spec.ts.snap
@@ -260,7 +260,6 @@ exports[`/@/src/components/molecules/constraints/ConstraintList.vue snapshot 1`]
             <div
               class="slider-forward"
             />
-            <!--v-if-->
           </div>
           
         </div>
@@ -292,7 +291,6 @@ exports[`/@/src/components/molecules/constraints/ConstraintList.vue snapshot 1`]
             <div
               class="slider-forward"
             />
-            <!--v-if-->
           </div>
           
         </div>
@@ -324,7 +322,6 @@ exports[`/@/src/components/molecules/constraints/ConstraintList.vue snapshot 1`]
             <div
               class="slider-forward"
             />
-            <!--v-if-->
           </div>
           <button
             type="button"
@@ -505,7 +502,6 @@ exports[`/@/src/components/molecules/constraints/ConstraintList.vue snapshot 1`]
               <div
                 class="slider-forward"
               />
-              <!--v-if-->
             </div>
           </div>
           
@@ -549,7 +545,6 @@ exports[`/@/src/components/molecules/constraints/ConstraintList.vue snapshot 1`]
               <div
                 class="slider-forward"
               />
-              <!--v-if-->
             </div>
           </div>
           
@@ -582,7 +577,6 @@ exports[`/@/src/components/molecules/constraints/ConstraintList.vue snapshot 1`]
             <div
               class="slider-forward"
             />
-            <!--v-if-->
           </div>
           <button
             type="button"

--- a/spec/components/panelContents/__snapshots__/GraphPanel.spec.ts.snap
+++ b/spec/components/panelContents/__snapshots__/GraphPanel.spec.ts.snap
@@ -30,7 +30,6 @@ exports[`src/components/panelContents/GraphPanel.vue snapshot no keyframe 1`] = 
         <div
           class="slider-forward"
         />
-        <!--v-if-->
       </div>
       
     </div>
@@ -71,7 +70,6 @@ exports[`src/components/panelContents/GraphPanel.vue snapshot with selected keyf
         <div
           class="slider-forward"
         />
-        <!--v-if-->
       </div>
       
     </div>
@@ -146,7 +144,6 @@ exports[`src/components/panelContents/GraphPanel.vue snapshot with selected keyf
         <div
           class="slider-forward"
         />
-        <!--v-if-->
       </div>
       
     </div>

--- a/src/components/AnimationPanel.vue
+++ b/src/components/AnimationPanel.vue
@@ -196,7 +196,11 @@ import { useAnimationLoop } from '../composables/animationLoop'
 import { useKeyframeEditMode } from '../composables/modes/keyframeEditMode'
 import ResizableH from '/@/components/atoms/ResizableH.vue'
 import { useCanvas } from '/@/composables/canvas'
-import { CurveSelectedState, KeyframeBase } from '/@/models/keyframe'
+import {
+  CurveSelectedState,
+  KeyframeBase,
+  KeyframeSelectedState,
+} from '/@/models/keyframe'
 import { useBooleanMap } from '/@/composables/idMap'
 import { Size } from 'okanvas'
 import {
@@ -243,13 +247,10 @@ function useCanvasMode(canvasType: Ref<CanvasType>) {
       downCurrentFrame() {
         mode.value.grabCurrentFrame()
       },
-      selectKeyframe(id: string, selectedState: { [key: string]: boolean }) {
+      selectKeyframe(id: string, selectedState: KeyframeSelectedState) {
         mode.value.select(id, selectedState)
       },
-      shiftSelectKeyframe(
-        id: string,
-        selectedState: { [key: string]: boolean }
-      ) {
+      shiftSelectKeyframe(id: string, selectedState: KeyframeSelectedState) {
         mode.value.shiftSelect(id, selectedState)
       },
       selectKeyframeByFrame(frame: number) {

--- a/src/components/atoms/SliderInput.vue
+++ b/src/components/atoms/SliderInput.vue
@@ -38,7 +38,6 @@ Copyright (C) 2021, Tomoya Komiyama.
       @mouseup="onUpForward"
       @mousedown.prevent="onDown"
     />
-    <GlobalCursor :p="cursor" :cursor="motion" />
   </div>
 </template>
 
@@ -48,10 +47,8 @@ import { computed, defineComponent, PropType, ref, watchEffect } from 'vue'
 import { useThrottle } from '/@/composables/throttle'
 import { usePointerLock } from '/@/composables/window'
 import { clamp, logRound } from '/@/utils/geometry'
-import GlobalCursor from '/@/components/atoms/GlobalCursor.vue'
 
 export default defineComponent({
-  components: { GlobalCursor },
   props: {
     modelValue: { type: Number, default: 0 },
     integer: {
@@ -217,8 +214,6 @@ export default defineComponent({
       onUpForward,
       input,
       scaleX,
-      cursor: pointerLock.current,
-      motion: pointerLock.motion,
     }
   },
 })

--- a/src/components/atoms/SliderInput.vue
+++ b/src/components/atoms/SliderInput.vue
@@ -79,7 +79,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const el = ref<Element>()
     const inputEl = ref<HTMLInputElement>()
-    const dragStartRate = ref(0)
+    const dragStartValue = ref(0)
     const focused = ref(false)
     const dragged = ref(false)
     const seriesKey = ref<string>()
@@ -110,10 +110,18 @@ export default defineComponent({
       }
     })
 
-    const rate = computed(() => {
+    function getRate(value: number): number {
       if (!range.value) return 0
       if (props.max === props.min) return 0
-      return (props.modelValue - props.min!) / (props.max! - props.min!)
+      return (value - props.min!) / (props.max! - props.min!)
+    }
+
+    const rate = computed(() => {
+      return getRate(props.modelValue)
+    })
+
+    const dragStartRate = computed(() => {
+      return getRate(dragStartValue.value)
     })
 
     const scaleX = computed(() => {
@@ -148,9 +156,11 @@ export default defineComponent({
           props.integer ? Math.round(val) : val
         ).toString()
       } else {
+        // the same speed as pixel is too high to slide
+        const diffX = (arg.p.x - arg.base.x) * 0.4
         draftValue.value = logRound(
           stepLog.value,
-          clampValue(parseDraftValue.value + arg.d.x * props.step)
+          clampValue(dragStartValue.value + diffX * props.step)
         ).toString()
       }
 
@@ -201,7 +211,7 @@ export default defineComponent({
       onDown: (e: MouseEvent) => {
         dragged.value = false
         seriesKey.value = `slider_${Date.now()}`
-        dragStartRate.value = rate.value
+        dragStartValue.value = props.modelValue
         pointerLock.requestPointerLock(e, 'move-h')
       },
       onUpForward,

--- a/src/components/atoms/SliderInput.vue
+++ b/src/components/atoms/SliderInput.vue
@@ -42,10 +42,9 @@ Copyright (C) 2021, Tomoya Komiyama.
 </template>
 
 <script lang="ts">
-import { IVec2 } from 'okageo'
 import { computed, defineComponent, PropType, ref, watchEffect } from 'vue'
 import { useThrottle } from '/@/composables/throttle'
-import { usePointerLock } from '/@/composables/window'
+import { PointerMovement, usePointerLock } from '/@/composables/window'
 import { clamp, logRound } from '/@/utils/geometry'
 
 export default defineComponent({
@@ -134,7 +133,7 @@ export default defineComponent({
       }
     }
 
-    function onDrag(arg: { base: IVec2; p: IVec2; d: IVec2 }) {
+    function onDrag(arg: PointerMovement) {
       if (!el.value) return
       const width = el.value.getBoundingClientRect().width
       if (width === 0) return

--- a/src/composables/modes/keyframeEditMode.ts
+++ b/src/composables/modes/keyframeEditMode.ts
@@ -154,6 +154,9 @@ export function useKeyframeEditMode(
     needLock: boolean
   } {
     switch (arg.key) {
+      case 'Escape':
+        cancel()
+        return notNeedLock
       case 'a':
         cancel()
         animationStore.selectAllKeyframes()
@@ -198,7 +201,6 @@ export function useKeyframeEditMode(
         cancel()
         return duplicate()
       default:
-        cancel()
         return notNeedLock
     }
   }


### PR DESCRIPTION
fix #181 


- feat: mousemove with shift key make the cursor slow
- style: hide the cursor when dragging a slider
- fix: invalid native mousemove handler