### PR TITLE
[Breaking] rename rotate parameter and some improvements

### DIFF
--- a/spec/components/elements/__snapshots__/GraphNode.spec.ts.snap
+++ b/spec/components/elements/__snapshots__/GraphNode.spec.ts.snap
@@ -36,17 +36,18 @@ exports[`src/components/elements/GraphNode.vue snapshot initial 1`] = `
     <g
       transform="translate(1, 2)"
     >
-      <g>
+      <g
+        class="edge-anchor"
+      >
         <rect
           fill="transparent"
           height="20"
           stroke="none"
-          width="30"
-          x="-30"
+          width="60"
+          x="-60"
           y="-10"
         />
         <text
-          class="view-only"
           dominant-baseline="middle"
           fill="#000"
           font-size="14"
@@ -57,7 +58,7 @@ exports[`src/components/elements/GraphNode.vue snapshot initial 1`] = `
         </text>
         <circle
           fill="transparent"
-          r="8"
+          r="10"
           stroke="none"
         />
       </g>
@@ -81,12 +82,14 @@ exports[`src/components/elements/GraphNode.vue snapshot initial 1`] = `
     <g
       transform="translate(1, 2)"
     >
-      <g>
+      <g
+        class="edge-anchor"
+      >
         <rect
           fill="transparent"
           height="20"
           stroke="none"
-          width="30"
+          width="60"
           y="-10"
         />
         <g
@@ -105,7 +108,7 @@ exports[`src/components/elements/GraphNode.vue snapshot initial 1`] = `
         </g>
         <circle
           fill="transparent"
-          r="8"
+          r="10"
           stroke="none"
         />
       </g>

--- a/spec/utils/graphNodes/index.spec.ts
+++ b/spec/utils/graphNodes/index.spec.ts
@@ -19,6 +19,7 @@ import {
   resetInput,
   duplicateNodes,
   createGraphNode,
+  getInput,
 } from '../../../src/utils/graphNodes/index'
 import { getTransform } from '/@/models'
 
@@ -207,6 +208,53 @@ describe('src/utils/graphNodes/index.ts', () => {
         y: 10,
       })
     })
+    it('should use default input value if the connection is invalid', () => {
+      expect(
+        compute(
+          context,
+          {},
+          {
+            id: 'break_vector2',
+            type: 'break_vector2',
+            data: {},
+            inputs: {
+              vector2: {
+                from: { id: 'make_vector2', key: 'vector2' },
+              },
+            },
+            position: { x: 0, y: 0 },
+          }
+        )
+      ).toEqual({ x: 0, y: 0 })
+    })
+  })
+
+  describe('getInput', () => {
+    it('should return default input value if it is not connected', () => {
+      expect(getInput({}, { a: { value: 1 } }, 'a')).toEqual(1)
+    })
+    it('should return connected output value if it is connected', () => {
+      expect(
+        getInput({ b: { c: 1 } }, { a: { from: { id: 'b', key: 'c' } } }, 'a')
+      ).toEqual(1)
+    })
+    it('should return default input value if connected node are not found', () => {
+      expect(
+        getInput({}, { a: { value: 1, from: { id: 'b', key: 'c' } } }, 'a')
+      ).toEqual(1)
+      expect(getInput({}, { a: { from: { id: 'b', key: 'c' } } }, 'a')).toEqual(
+        undefined
+      )
+    })
+    it('should return default input value if the key of connected node are not found', () => {
+      expect(
+        getInput(
+          { b: {} },
+          { a: { value: 1, from: { id: 'b', key: 'c' } } },
+          'a'
+        )
+      ).toEqual(1)
+    })
   })
 
   describe('getInputFromIds', () => {
@@ -366,7 +414,7 @@ describe('src/utils/graphNodes/index.ts', () => {
     it('should override partial inputs', () => {
       expect(
         createGraphNode('make_vector2', {
-          inputs: { x: { from: { id: 'a', key: 'b' } } },
+          inputs: { x: { from: { id: 'a', key: 'b' } } } as any,
         })
       ).toEqual({
         ...createGraphNode('make_vector2'),

--- a/spec/utils/graphNodes/index.spec.ts
+++ b/spec/utils/graphNodes/index.spec.ts
@@ -361,4 +361,20 @@ describe('src/utils/graphNodes/index.ts', () => {
       })
     })
   })
+
+  describe('createGraphNode', () => {
+    it('should override partial inputs', () => {
+      expect(
+        createGraphNode('make_vector2', {
+          inputs: { x: { from: { id: 'a', key: 'b' } } },
+        })
+      ).toEqual({
+        ...createGraphNode('make_vector2'),
+        inputs: {
+          x: { from: { id: 'a', key: 'b' } },
+          y: { value: 0 },
+        },
+      })
+    })
+  })
 })

--- a/spec/utils/graphNodes/nodes/cos.spec.ts
+++ b/spec/utils/graphNodes/nodes/cos.spec.ts
@@ -25,7 +25,7 @@ describe('src/utils/graphNodes/nodes/cos.ts', () => {
       expect(
         target.struct.computation(
           {
-            t: 0,
+            rotate: 0,
           },
           {} as any,
           {} as any

--- a/spec/utils/graphNodes/nodes/invertPolarCoord.spec.ts
+++ b/spec/utils/graphNodes/nodes/invertPolarCoord.spec.ts
@@ -1,0 +1,37 @@
+/*
+This file is part of Blendic SVG.
+
+Blendic SVG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Blendic SVG is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Blendic SVG.  If not, see <https://www.gnu.org/licenses/>.
+
+Copyright (C) 2021, Tomoya Komiyama.
+*/
+
+import * as target from '/@/utils/graphNodes/nodes/invertPolarCoord'
+
+describe('src/utils/graphNodes/nodes/invertPolarCoord.ts', () => {
+  describe('computation', () => {
+    it('should return invert polar coord of the input parameters', () => {
+      const ret = target.struct.computation(
+        {
+          vector2: { x: 0, y: 3 },
+        },
+        {} as any,
+        {} as any
+      ) as any
+
+      expect(ret.rotate).toBeCloseTo(90)
+      expect(ret.radius).toBeCloseTo(3)
+    })
+  })
+})

--- a/spec/utils/graphNodes/nodes/polarCoord.spec.ts
+++ b/spec/utils/graphNodes/nodes/polarCoord.spec.ts
@@ -1,0 +1,38 @@
+/*
+This file is part of Blendic SVG.
+
+Blendic SVG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Blendic SVG is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Blendic SVG.  If not, see <https://www.gnu.org/licenses/>.
+
+Copyright (C) 2021, Tomoya Komiyama.
+*/
+
+import * as target from '/@/utils/graphNodes/nodes/polarCoord'
+
+describe('src/utils/graphNodes/nodes/polarCoord.ts', () => {
+  describe('computation', () => {
+    it('should return polar coord of the input parameters', () => {
+      const ret = target.struct.computation(
+        {
+          rotate: 90,
+          radius: 2,
+        },
+        {} as any,
+        {} as any
+      ) as any
+
+      expect(ret.vector2.x).toBeCloseTo(0)
+      expect(ret.vector2.y).toBeCloseTo(2)
+    })
+  })
+})

--- a/spec/utils/graphNodes/nodes/sin.spec.ts
+++ b/spec/utils/graphNodes/nodes/sin.spec.ts
@@ -25,7 +25,7 @@ describe('src/utils/graphNodes/nodes/sin.ts', () => {
       expect(
         target.struct.computation(
           {
-            t: 90,
+            rotate: 90,
           },
           {} as any,
           {} as any

--- a/src/components/AnimationGraphCanvas.vue
+++ b/src/components/AnimationGraphCanvas.vue
@@ -212,7 +212,7 @@ export default defineComponent({
         }
 
         props.canvas.upLeft()
-        props.mode.upLeft()
+        props.mode.upLeft({ empty: e.target === svg.value })
         isDownEmpty.value = false
       },
       downMiddle: (e: MouseEvent) => {

--- a/src/components/elements/GraphNode.vue
+++ b/src/components/elements/GraphNode.vue
@@ -54,6 +54,7 @@ Copyright (C) 2021, Tomoya Komiyama.
         :transform="`translate(${edge.p.x}, ${edge.p.y})`"
       >
         <g
+          class="edge-anchor"
           @mouseup.left.exact="upToEdge(key)"
           @mousedown.left.exact.prevent="downToEdge(key)"
         >
@@ -71,10 +72,9 @@ Copyright (C) 2021, Tomoya Komiyama.
             text-anchor="end"
             font-size="14"
             fill="#000"
-            class="view-only"
             >{{ key }}</text
           >
-          <circle r="8" fill="transparent" stroke="none" />
+          <circle r="10" fill="transparent" stroke="none" />
         </g>
         <circle
           r="5"
@@ -107,6 +107,7 @@ Copyright (C) 2021, Tomoya Komiyama.
         :transform="`translate(${edge.p.x}, ${edge.p.y})`"
       >
         <g
+          class="edge-anchor"
           @mouseup.left.exact="upFromEdge(key)"
           @mousedown.left.exact.prevent="downFromEdge(key)"
         >
@@ -124,7 +125,7 @@ Copyright (C) 2021, Tomoya Komiyama.
               :input="node.inputs[key]"
             />
           </g>
-          <circle r="8" fill="transparent" stroke="none" />
+          <circle r="10" fill="transparent" stroke="none" />
         </g>
         <circle
           r="5"
@@ -252,7 +253,7 @@ export default defineComponent({
         props.selected ? settings.selectedColor : '#555'
       ),
       getInputType,
-      edgeAnchorWidth: computed(() => 30),
+      edgeAnchorWidth: computed(() => 60),
       outlineStrokeWidth: computed(() => (props.selected ? 2 : 1)),
       dataMap,
       downBody(e: MouseEvent) {
@@ -288,5 +289,11 @@ export default defineComponent({
 <style lang="scss" scoped>
 .view-only {
   pointer-events: none;
+}
+.edge-anchor:hover {
+  circle {
+    transition: fill 0.2s;
+    fill: #ffa07a;
+  }
 }
 </style>

--- a/src/composables/modes/animationGraphMode.ts
+++ b/src/composables/modes/animationGraphMode.ts
@@ -190,7 +190,7 @@ export function useAnimationGraphMode(graphStore: AnimationGraphStore) {
     })
   }
 
-  function upLeft() {
+  function upLeft(options?: { empty: boolean }) {
     if (state.command === 'drag-edge' && state.dragTarget?.type === 'edge') {
       if (state.closestEdgeInfo && isValidDraftConnection.value) {
         if (state.dragTarget.draftGraphEdge.type === 'draft-to') {
@@ -231,13 +231,17 @@ export function useAnimationGraphMode(graphStore: AnimationGraphStore) {
           }
           cancel()
         } else {
-          // save the edge type and suggest relational nodes
-          const from = state.dragTarget.draftGraphEdge.from
-          const node = graphStore.nodeMap.value[from.nodeId]
-          const struct = getGraphNodeModule(node.type).struct
-          state.nodeSuggestion = struct.outputs[from.key]
-          state.keyDownPosition = state.editMovement!.current
-          state.command = 'add'
+          if (options?.empty) {
+            // save the edge type and suggest relational nodes
+            const from = state.dragTarget.draftGraphEdge.from
+            const node = graphStore.nodeMap.value[from.nodeId]
+            const struct = getGraphNodeModule(node.type).struct
+            state.nodeSuggestion = struct.outputs[from.key]
+            state.keyDownPosition = state.editMovement!.current
+            state.command = 'add'
+          } else {
+            cancel()
+          }
         }
       }
     } else if (state.command) {

--- a/src/composables/modes/animationGraphMode.ts
+++ b/src/composables/modes/animationGraphMode.ts
@@ -33,10 +33,13 @@ import {
   GraphNode,
   GraphNodeType,
   GraphNodeInput,
+  GRAPH_VALUE_TYPE_KEY,
 } from '/@/models/graphNode'
 import {
   duplicateNodes,
+  getGraphNodeModule,
   NODE_MENU_OPTIONS_SRC,
+  NODE_SUGGESTION_MENU_OPTIONS_SRC,
   resetInput,
   validateConnection,
 } from '/@/utils/graphNodes'
@@ -81,6 +84,7 @@ interface State {
     | { type: 'edge'; draftGraphEdge: DraftGraphEdge }
     | undefined
   closestEdgeInfo: EdgeInfo | undefined
+  nodeSuggestion: GRAPH_VALUE_TYPE_KEY | undefined
 }
 
 const notNeedLock = { needLock: false }
@@ -94,6 +98,7 @@ export function useAnimationGraphMode(graphStore: AnimationGraphStore) {
     keyDownPosition: { x: 0, y: 0 },
     dragTarget: undefined,
     closestEdgeInfo: undefined,
+    nodeSuggestion: undefined,
   })
   const selectedNodes = computed(() => graphStore.selectedNodes.value)
   const lastSelectedNodeId = computed(
@@ -111,6 +116,7 @@ export function useAnimationGraphMode(graphStore: AnimationGraphStore) {
     state.editMovement = undefined
     state.dragTarget = undefined
     state.closestEdgeInfo = undefined
+    state.nodeSuggestion = undefined
   }
 
   function clickAny() {
@@ -206,6 +212,7 @@ export function useAnimationGraphMode(graphStore: AnimationGraphStore) {
             state.closestEdgeInfo.key
           )
         }
+        cancel()
       } else {
         if (state.dragTarget.draftGraphEdge.type === 'draft-from') {
           const to = state.dragTarget.draftGraphEdge.to
@@ -222,9 +229,17 @@ export function useAnimationGraphMode(graphStore: AnimationGraphStore) {
               } as any,
             })
           }
+          cancel()
+        } else {
+          // save the edge type and suggest relational nodes
+          const from = state.dragTarget.draftGraphEdge.from
+          const node = graphStore.nodeMap.value[from.nodeId]
+          const struct = getGraphNodeModule(node.type).struct
+          state.nodeSuggestion = struct.outputs[from.key]
+          state.keyDownPosition = state.editMovement!.current
+          state.command = 'add'
         }
       }
-      cancel()
     } else if (state.command) {
       completeEdit()
     }
@@ -468,10 +483,52 @@ export function useAnimationGraphMode(graphStore: AnimationGraphStore) {
   )
   watch(() => state.command, addMenuList.clearOpened)
 
+  const addAndConnectMenuList = mapReduce(
+    NODE_SUGGESTION_MENU_OPTIONS_SRC,
+    (src) => {
+      return useMenuList(() =>
+        src.map(({ label, type, key }) => ({
+          label,
+          exec: () => addAndConnectNode(type, key),
+        }))
+      )
+    }
+  )
+
+  const draftEdgeFrom = computed(() => {
+    if (
+      state.dragTarget?.type !== 'edge' ||
+      state.dragTarget.draftGraphEdge.type === 'draft-from'
+    )
+      return
+
+    return state.dragTarget.draftGraphEdge.from
+  })
+
+  // add new node and connect draft edge to it
+  function addAndConnectNode(type: GraphNodeType, key: string) {
+    const from = draftEdgeFrom.value
+    if (!from) return
+
+    graphStore.addNode(type, {
+      position: state.keyDownPosition,
+      inputs: {
+        [key]: { from: { id: from.nodeId, key: from.key } },
+      },
+    })
+    cancel()
+  }
+
+  const popupToAddMenuList = computed<PopupMenuItem[]>(() => {
+    if (state.nodeSuggestion)
+      return addAndConnectMenuList[state.nodeSuggestion].list.value
+    return addMenuList.list.value
+  })
+
   const popupMenuList = computed<PopupMenuItem[]>(() => {
     switch (state.command) {
       case 'add':
-        return addMenuList.list.value
+        return popupToAddMenuList.value
       default:
         return []
     }

--- a/src/models/graphNode.ts
+++ b/src/models/graphNode.ts
@@ -417,12 +417,12 @@ export interface GraphNodeDivideScaler extends GraphNodeBase {
 
 export interface GraphNodeSin extends GraphNodeBase {
   type: 'sin'
-  inputs: { t: GraphNodeInput<number> }
+  inputs: { rotate: GraphNodeInput<number> }
 }
 
 export interface GraphNodeCos extends GraphNodeBase {
   type: 'cos'
-  inputs: { t: GraphNodeInput<number> }
+  inputs: { rotate: GraphNodeInput<number> }
 }
 
 export interface GraphNodePow extends GraphNodeBase {

--- a/src/models/graphNode.ts
+++ b/src/models/graphNode.ts
@@ -124,6 +124,7 @@ export interface GraphNodes {
   divide_scaler: GraphNodeDivideScaler
   sin: GraphNodeSin
   cos: GraphNodeCos
+  polar_coord: GraphNodePolarCoord
   pow: GraphNodePow
   rotate_vector2: GraphNodeRotateVector2
   add_vector2: GraphNodeAddVector2
@@ -423,6 +424,11 @@ export interface GraphNodeSin extends GraphNodeBase {
 export interface GraphNodeCos extends GraphNodeBase {
   type: 'cos'
   inputs: { rotate: GraphNodeInput<number> }
+}
+
+export interface GraphNodePolarCoord extends GraphNodeBase {
+  type: 'polar_coord'
+  inputs: { rotate: GraphNodeInput<number>; radius: GraphNodeInput<number> }
 }
 
 export interface GraphNodePow extends GraphNodeBase {

--- a/src/models/graphNode.ts
+++ b/src/models/graphNode.ts
@@ -125,6 +125,7 @@ export interface GraphNodes {
   sin: GraphNodeSin
   cos: GraphNodeCos
   polar_coord: GraphNodePolarCoord
+  invert_polar_coord: GraphNodeInvertPolarCoord
   pow: GraphNodePow
   rotate_vector2: GraphNodeRotateVector2
   add_vector2: GraphNodeAddVector2
@@ -429,6 +430,11 @@ export interface GraphNodeCos extends GraphNodeBase {
 export interface GraphNodePolarCoord extends GraphNodeBase {
   type: 'polar_coord'
   inputs: { rotate: GraphNodeInput<number>; radius: GraphNodeInput<number> }
+}
+
+export interface GraphNodeInvertPolarCoord extends GraphNodeBase {
+  type: 'invert_polar_coord'
+  inputs: { vector2: GraphNodeInput<IVec2> }
 }
 
 export interface GraphNodePow extends GraphNodeBase {

--- a/src/utils/graphNodes/core.ts
+++ b/src/utils/graphNodes/core.ts
@@ -34,10 +34,9 @@ export interface NodeStruct<T extends GraphNodeBase> {
     [key in keyof T['data']]: { type: keyof typeof GRAPH_VALUE_TYPE }
   }
   inputs: {
-    [key in keyof T['inputs']]: { type: keyof typeof GRAPH_VALUE_TYPE } & (
-      | { default: Required<T['inputs'][key]>['value'] }
-      | { required: true }
-    )
+    [key in keyof T['inputs']]: { type: keyof typeof GRAPH_VALUE_TYPE } & {
+      default: Required<T['inputs'][key]>['value']
+    }
   }
   outputs: {
     [key: string]: keyof typeof GRAPH_VALUE_TYPE

--- a/src/utils/graphNodes/index.ts
+++ b/src/utils/graphNodes/index.ts
@@ -25,6 +25,7 @@ import {
   GraphNodeOutputValues,
   GraphNodes,
   GraphNodeType,
+  GRAPH_VALUE_TYPE_KEY,
 } from '/@/models/graphNode'
 import { NodeModule, NodeContext } from '/@/utils/graphNodes/core'
 import { v4 } from 'uuid'
@@ -152,10 +153,33 @@ const NODE_MODULES: { [key in GraphNodeType]: NodeModule<any> } = {
   switch_object,
 } as const
 
-export const NODE_MENU_OPTIONS_SRC: {
+interface NodeMenuOption {
   label: string
-  children: { label: string; type: GraphNodeType }[]
-}[] = [
+  type: GraphNodeType
+}
+
+interface NODE_MENU_OPTION {
+  label: string
+  children: NodeMenuOption[]
+}
+
+const MAKE_PATH_SRC: NODE_MENU_OPTION = {
+  label: 'Make Path',
+  children: [
+    { label: 'M (Move)', type: 'make_path_m' },
+    { label: 'L (Line)', type: 'make_path_l' },
+    { label: 'H (Horizon)', type: 'make_path_h' },
+    { label: 'V (Vertical)', type: 'make_path_v' },
+    { label: 'Q (Bezier2)', type: 'make_path_q' },
+    { label: 'T (Bezier2)', type: 'make_path_t' },
+    { label: 'C (Bezier3)', type: 'make_path_c' },
+    { label: 'S (Bezier3)', type: 'make_path_s' },
+    { label: 'A (Arc)', type: 'make_path_a' },
+    { label: 'Z (Close)', type: 'make_path_z' },
+  ],
+}
+
+export const NODE_MENU_OPTIONS_SRC: NODE_MENU_OPTION[] = [
   {
     label: 'Primitive',
     children: [
@@ -226,22 +250,58 @@ export const NODE_MENU_OPTIONS_SRC: {
       { label: 'Path', type: 'create_object_path' },
     ],
   },
-  {
-    label: 'Make Path',
-    children: [
-      { label: 'M (Move)', type: 'make_path_m' },
-      { label: 'L (Line)', type: 'make_path_l' },
-      { label: 'H (Horizon)', type: 'make_path_h' },
-      { label: 'V (Vertical)', type: 'make_path_v' },
-      { label: 'Q (Bezier2)', type: 'make_path_q' },
-      { label: 'T (Bezier2)', type: 'make_path_t' },
-      { label: 'C (Bezier3)', type: 'make_path_c' },
-      { label: 'S (Bezier3)', type: 'make_path_s' },
-      { label: 'A (Arc)', type: 'make_path_a' },
-      { label: 'Z (Close)', type: 'make_path_z' },
-    ],
-  },
+  MAKE_PATH_SRC,
 ]
+
+export const NODE_SUGGESTION_MENU_OPTIONS_SRC: {
+  [key in GRAPH_VALUE_TYPE_KEY]: ({ key: string } & NodeMenuOption)[]
+} = {
+  BOOLEAN: [
+    { label: 'Not', type: 'not', key: 'condition' },
+    { label: 'Switch Number', type: 'switch_scaler', key: 'condition' },
+    { label: 'Switch Vector2', type: 'switch_vector2', key: 'condition' },
+    { label: 'Switch Transform', type: 'switch_transform', key: 'condition' },
+    { label: 'Switch Object', type: 'switch_object', key: 'condition' },
+  ],
+  SCALER: [
+    { label: '(+) Number', type: 'add_scaler', key: 'a' },
+    { label: '(-) Number', type: 'sub_scaler', key: 'a' },
+    { label: '(x) Number', type: 'multi_scaler', key: 'a' },
+    { label: '(/) Number', type: 'divide_scaler', key: 'a' },
+    { label: 'Sin', type: 'sin', key: 'rotate' },
+    { label: 'Cos', type: 'cos', key: 'rotate' },
+    { label: 'Pow', type: 'pow', key: 'x' },
+    { label: '(=) Number', type: 'equal', key: 'a' },
+    { label: '(>) Number', type: 'greater_than', key: 'a' },
+    { label: '(>=) Number', type: 'greater_than_or_equal', key: 'a' },
+    { label: '(<) Number', type: 'less_than', key: 'a' },
+    { label: '(<=) Number', type: 'less_than_or_equal', key: 'a' },
+    { label: 'Make Vector2', type: 'make_vector2', key: 'x' },
+    { label: 'Lerp Number', type: 'lerp_scaler', key: 'a' },
+  ],
+  VECTOR2: [
+    { label: '(+) Vector2', type: 'add_vector2', key: 'a' },
+    { label: '(-) Vector2', type: 'sub_vector2', key: 'a' },
+    { label: 'Scale Vector2', type: 'scale_vector2', key: 'vector2' },
+    { label: 'Distance', type: 'distance', key: 'a' },
+    { label: 'Rotate Vector2', type: 'rotate_vector2', key: 'vector2' },
+    { label: 'Make Transform', type: 'make_transform', key: 'translate' },
+    { label: 'Lerp Vector2', type: 'lerp_vector2', key: 'a' },
+  ],
+  OBJECT: [
+    { label: 'Set Transform', type: 'set_transform', key: 'object' },
+    { label: 'Set Fill', type: 'set_fill', key: 'object' },
+    { label: 'Set Stroke', type: 'set_stroke', key: 'object' },
+    { label: 'Set Viewbox', type: 'set_viewbox', key: 'object' },
+    { label: 'Clone Object', type: 'clone_object', key: 'object' },
+  ],
+  TRANSFORM: [{ label: 'Lerp Transform', type: 'lerp_transform', key: 'a' }],
+  COLOR: [
+    { label: 'Break Color', type: 'break_color', key: 'color' },
+    { label: 'Lerp Color', type: 'lerp_color', key: 'a' },
+  ],
+  D: MAKE_PATH_SRC.children.map((c) => ({ ...c, key: 'd' })),
+}
 
 export function getGraphNodeModule<T extends GraphNodeType>(
   type: T
@@ -380,10 +440,17 @@ export function validateInput<T extends GraphNodeInputs>(
 
 export function createGraphNode<T extends GraphNodeType>(
   type: T,
-  arg: Partial<GraphNodes[T]> = {},
+  arg: Partial<Omit<GraphNodes[T], 'inputs'>> & {
+    inputs?: Partial<GraphNodes[T]['inputs']>
+  } = {},
   generateId = false
 ): GraphNodes[T] {
-  const node = NODE_MODULES[type].struct.create(arg)
+  // enable to override partial inputs
+  const { inputs, ...others } = arg
+  const node = NODE_MODULES[type].struct.create(others)
+  if (inputs) {
+    node.inputs = { ...node.inputs, ...arg.inputs }
+  }
   if (generateId) {
     node.id = v4()
   }

--- a/src/utils/graphNodes/index.ts
+++ b/src/utils/graphNodes/index.ts
@@ -43,6 +43,7 @@ import * as multi_scaler from './nodes/multiScaler'
 import * as divide_scaler from './nodes/divideScaler'
 import * as sin from './nodes/sin'
 import * as cos from './nodes/cos'
+import * as polar_coord from './nodes/polarCoord'
 import * as pow from './nodes/pow'
 import * as add_vector2 from './nodes/addVector2'
 import * as sub_vector2 from './nodes/subVector2'
@@ -104,6 +105,7 @@ const NODE_MODULES: { [key in GraphNodeType]: NodeModule<any> } = {
   divide_scaler,
   sin,
   cos,
+  polar_coord,
   pow,
   add_vector2,
   sub_vector2,
@@ -176,6 +178,7 @@ export const NODE_MENU_OPTIONS_SRC: {
       { label: '(/) Number', type: 'divide_scaler' },
       { label: 'Sin', type: 'sin' },
       { label: 'Cos', type: 'cos' },
+      { label: 'Polar Coord', type: 'polar_coord' },
       { label: 'Pow', type: 'pow' },
       { label: '(+) Vector2', type: 'add_vector2' },
       { label: '(-) Vector2', type: 'sub_vector2' },

--- a/src/utils/graphNodes/index.ts
+++ b/src/utils/graphNodes/index.ts
@@ -307,7 +307,10 @@ export const NODE_SUGGESTION_MENU_OPTIONS_SRC: {
     { label: 'Break Color', type: 'break_color', key: 'color' },
     { label: 'Lerp Color', type: 'lerp_color', key: 'a' },
   ],
-  D: MAKE_PATH_SRC.children.map((c) => ({ ...c, key: 'd' })),
+  D: [
+    ...MAKE_PATH_SRC.children.map((c) => ({ ...c, key: 'd' })),
+    { label: 'Create Path', type: 'create_object_path', key: 'd' },
+  ],
 }
 
 export function getGraphNodeModule<T extends GraphNodeType>(

--- a/src/utils/graphNodes/index.ts
+++ b/src/utils/graphNodes/index.ts
@@ -45,6 +45,7 @@ import * as divide_scaler from './nodes/divideScaler'
 import * as sin from './nodes/sin'
 import * as cos from './nodes/cos'
 import * as polar_coord from './nodes/polarCoord'
+import * as invert_polar_coord from './nodes/invertPolarCoord'
 import * as pow from './nodes/pow'
 import * as add_vector2 from './nodes/addVector2'
 import * as sub_vector2 from './nodes/subVector2'
@@ -107,6 +108,7 @@ const NODE_MODULES: { [key in GraphNodeType]: NodeModule<any> } = {
   sin,
   cos,
   polar_coord,
+  invert_polar_coord,
   pow,
   add_vector2,
   sub_vector2,
@@ -203,6 +205,7 @@ export const NODE_MENU_OPTIONS_SRC: NODE_MENU_OPTION[] = [
       { label: 'Sin', type: 'sin' },
       { label: 'Cos', type: 'cos' },
       { label: 'Polar Coord', type: 'polar_coord' },
+      { label: 'Invert Polar Coord', type: 'invert_polar_coord' },
       { label: 'Pow', type: 'pow' },
       { label: '(+) Vector2', type: 'add_vector2' },
       { label: '(-) Vector2', type: 'sub_vector2' },
@@ -277,6 +280,8 @@ export const NODE_SUGGESTION_MENU_OPTIONS_SRC: {
     { label: '(<) Number', type: 'less_than', key: 'a' },
     { label: '(<=) Number', type: 'less_than_or_equal', key: 'a' },
     { label: 'Make Vector2', type: 'make_vector2', key: 'x' },
+    { label: 'Make Transform', type: 'make_transform', key: 'rotate' },
+    { label: 'Polar Coord', type: 'polar_coord', key: 'rotate' },
     { label: 'Lerp Number', type: 'lerp_scaler', key: 'a' },
   ],
   VECTOR2: [
@@ -285,6 +290,8 @@ export const NODE_SUGGESTION_MENU_OPTIONS_SRC: {
     { label: 'Scale Vector2', type: 'scale_vector2', key: 'vector2' },
     { label: 'Distance', type: 'distance', key: 'a' },
     { label: 'Rotate Vector2', type: 'rotate_vector2', key: 'vector2' },
+    { label: 'Break Vector2', type: 'break_vector2', key: 'vector2' },
+    { label: 'Invert Polar Coord', type: 'invert_polar_coord', key: 'vector2' },
     { label: 'Make Transform', type: 'make_transform', key: 'translate' },
     { label: 'Lerp Vector2', type: 'lerp_vector2', key: 'a' },
   ],

--- a/src/utils/graphNodes/nodes/breakVector2.ts
+++ b/src/utils/graphNodes/nodes/breakVector2.ts
@@ -32,7 +32,7 @@ export const struct: NodeStruct<GraphNodeBreakVector2> = {
   },
   data: {},
   inputs: {
-    vector2: { type: GRAPH_VALUE_TYPE.VECTOR2, required: true },
+    vector2: { type: GRAPH_VALUE_TYPE.VECTOR2, default: { x: 0, y: 0 } },
   },
   outputs: {
     x: GRAPH_VALUE_TYPE.SCALER,

--- a/src/utils/graphNodes/nodes/cos.ts
+++ b/src/utils/graphNodes/nodes/cos.ts
@@ -24,7 +24,7 @@ export const struct: NodeStruct<GraphNodeCos> = {
   create(arg = {}) {
     return {
       ...createBaseNode({
-        inputs: { t: { value: 0 } },
+        inputs: { rotate: { value: 0 } },
         ...arg,
       }),
       type: 'cos',
@@ -32,13 +32,13 @@ export const struct: NodeStruct<GraphNodeCos> = {
   },
   data: {},
   inputs: {
-    t: { type: GRAPH_VALUE_TYPE.SCALER, default: 0 },
+    rotate: { type: GRAPH_VALUE_TYPE.SCALER, default: 0 },
   },
   outputs: {
     value: GRAPH_VALUE_TYPE.SCALER,
   },
   computation(inputs) {
-    return { value: Math.cos((inputs.t * Math.PI) / 180) }
+    return { value: Math.cos((inputs.rotate * Math.PI) / 180) }
   },
   width: 100,
   color: '#4169e1',

--- a/src/utils/graphNodes/nodes/invertPolarCoord.ts
+++ b/src/utils/graphNodes/nodes/invertPolarCoord.ts
@@ -1,0 +1,54 @@
+/*
+This file is part of Blendic SVG.
+
+Blendic SVG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Blendic SVG is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Blendic SVG.  If not, see <https://www.gnu.org/licenses/>.
+
+Copyright (C) 2021, Tomoya Komiyama.
+*/
+
+import { getNorm, getRadian } from 'okageo'
+import {
+  GraphNodeInvertPolarCoord,
+  GRAPH_VALUE_TYPE,
+} from '/@/models/graphNode'
+import { createBaseNode, NodeStruct } from '/@/utils/graphNodes/core'
+
+export const struct: NodeStruct<GraphNodeInvertPolarCoord> = {
+  create(arg = {}) {
+    return {
+      ...createBaseNode({
+        inputs: { vector2: { value: { x: 1, y: 0 } } },
+        ...arg,
+      }),
+      type: 'invert_polar_coord',
+    } as GraphNodeInvertPolarCoord
+  },
+  data: {},
+  inputs: {
+    vector2: { type: GRAPH_VALUE_TYPE.VECTOR2, default: { x: 1, y: 0 } },
+  },
+  outputs: {
+    rotate: GRAPH_VALUE_TYPE.SCALER,
+    radius: GRAPH_VALUE_TYPE.SCALER,
+  },
+  computation(inputs): { rotate: number; radius: number } {
+    const radius = getNorm(inputs.vector2)
+    const rotate = (getRadian(inputs.vector2) * 180) / Math.PI
+    return { rotate, radius }
+  },
+  width: 160,
+  color: '#4169e1',
+  textColor: '#fff',
+  label: 'Invert Polar Coord',
+}

--- a/src/utils/graphNodes/nodes/polarCoord.ts
+++ b/src/utils/graphNodes/nodes/polarCoord.ts
@@ -1,0 +1,55 @@
+/*
+This file is part of Blendic SVG.
+
+Blendic SVG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Blendic SVG is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Blendic SVG.  If not, see <https://www.gnu.org/licenses/>.
+
+Copyright (C) 2021, Tomoya Komiyama.
+*/
+
+import { IVec2 } from 'okageo'
+import { GraphNodePolarCoord, GRAPH_VALUE_TYPE } from '/@/models/graphNode'
+import { createBaseNode, NodeStruct } from '/@/utils/graphNodes/core'
+
+export const struct: NodeStruct<GraphNodePolarCoord> = {
+  create(arg = {}) {
+    return {
+      ...createBaseNode({
+        inputs: { rotate: { value: 0 }, radius: { value: 1 } },
+        ...arg,
+      }),
+      type: 'polar_coord',
+    } as GraphNodePolarCoord
+  },
+  data: {},
+  inputs: {
+    rotate: { type: GRAPH_VALUE_TYPE.SCALER, default: 0 },
+    radius: { type: GRAPH_VALUE_TYPE.SCALER, default: 1 },
+  },
+  outputs: {
+    vector2: GRAPH_VALUE_TYPE.VECTOR2,
+  },
+  computation(inputs): { vector2: IVec2 } {
+    const r = (inputs.rotate * Math.PI) / 180
+    return {
+      vector2: {
+        x: inputs.radius * Math.cos(r),
+        y: inputs.radius * Math.sin(r),
+      },
+    }
+  },
+  width: 140,
+  color: '#4169e1',
+  textColor: '#fff',
+  label: 'Polar Coord',
+}

--- a/src/utils/graphNodes/nodes/sin.ts
+++ b/src/utils/graphNodes/nodes/sin.ts
@@ -24,7 +24,7 @@ export const struct: NodeStruct<GraphNodeSin> = {
   create(arg = {}) {
     return {
       ...createBaseNode({
-        inputs: { t: { value: 0 } },
+        inputs: { rotate: { value: 0 } },
         ...arg,
       }),
       type: 'sin',
@@ -32,13 +32,13 @@ export const struct: NodeStruct<GraphNodeSin> = {
   },
   data: {},
   inputs: {
-    t: { type: GRAPH_VALUE_TYPE.SCALER, default: 0 },
+    rotate: { type: GRAPH_VALUE_TYPE.SCALER, default: 0 },
   },
   outputs: {
     value: GRAPH_VALUE_TYPE.SCALER,
   },
   computation(inputs) {
-    return { value: Math.sin((inputs.t * Math.PI) / 180) }
+    return { value: Math.sin((inputs.rotate * Math.PI) / 180) }
   },
   width: 100,
   color: '#4169e1',


### PR DESCRIPTION
- feat: show suggestions of new node to connect draft output edge
![image](https://user-images.githubusercontent.com/20733354/124138915-140f7500-dac2-11eb-8008-205c5b0ba420.png)

- fix: [breaking] rename rotate parameter name of sin and cos nodes
`t` => `rotate`
- fix: use default input value if the connection may be invalid
deleting nodes had caused these exceptions
- feat: add new node to transform polar coord