### PR TITLE
feat: set fill and stroke recursively

### DIFF
--- a/spec/utils/color.spec.ts
+++ b/spec/utils/color.spec.ts
@@ -161,6 +161,20 @@ describe('src/utils/color.ts', () => {
         a: 0.9,
       })
     })
+    it('should clump hue circulary', () => {
+      expect(hsvaToRgba({ h: -360, s: 1, v: 1, a: 1 })).toEqual({
+        r: 255,
+        g: 0,
+        b: 0,
+        a: 1,
+      })
+      expect(hsvaToRgba({ h: 720, s: 1, v: 1, a: 1 })).toEqual({
+        r: 255,
+        g: 0,
+        b: 0,
+        a: 1,
+      })
+    })
   })
 
   describe('hslaToHsva', () => {

--- a/spec/utils/elements.spec.ts
+++ b/spec/utils/elements.spec.ts
@@ -384,48 +384,96 @@ describe('utils/elements.ts', () => {
       context.setTransform('a', getTransform({ rotate: 20 }))
       expect(context.getTransform('a')).toEqual(getTransform({ rotate: 20 }))
     })
-    it('should return a context to setFill', () => {
-      const context = createGraphNodeContext(
-        { a: getBElement({ id: 'a' }) },
-        10
-      )
-      context.setFill('a', getTransform({ rotate: 20 }))
-      expect(context.getObjectMap()).toEqual({
-        a: {
-          id: 'a',
-          elementId: 'a',
-          fill: getTransform({ rotate: 20 }),
-        },
+    describe('should return a context to setFill', () => {
+      it('to set fill', () => {
+        const context = createGraphNodeContext(
+          { a: getBElement({ id: 'a' }) },
+          10
+        )
+        context.setFill('a', getTransform({ rotate: 20 }))
+        expect(context.getObjectMap()).toEqual({
+          a: {
+            id: 'a',
+            elementId: 'a',
+            fill: getTransform({ rotate: 20 }),
+          },
+        })
+        context.setFill('a', getTransform({ rotate: 50 }))
+        expect(context.getObjectMap()).toEqual({
+          a: {
+            id: 'a',
+            elementId: 'a',
+            fill: getTransform({ rotate: 50 }),
+          },
+        })
       })
-      context.setFill('a', getTransform({ rotate: 50 }))
-      expect(context.getObjectMap()).toEqual({
-        a: {
-          id: 'a',
-          elementId: 'a',
-          fill: getTransform({ rotate: 50 }),
-        },
+      it('to set fill recursively', () => {
+        const context = createGraphNodeContext({}, 10)
+        const g1 = context.createObject('g')
+        const rect1 = context.createObject('rect', { parent: g1 })
+        context.setFill(g1, getTransform({ rotate: 20 }))
+
+        expect(context.getObjectMap()).toEqual({
+          [g1]: {
+            id: g1,
+            tag: 'g',
+            fill: getTransform({ rotate: 20 }),
+            create: true,
+          },
+          [rect1]: {
+            id: rect1,
+            tag: 'rect',
+            parent: g1,
+            fill: getTransform({ rotate: 20 }),
+            create: true,
+          },
+        })
       })
     })
-    it('should return a context to setStroke', () => {
-      const context = createGraphNodeContext(
-        { a: getBElement({ id: 'a' }) },
-        10
-      )
-      context.setStroke('a', getTransform({ rotate: 20 }))
-      expect(context.getObjectMap()).toEqual({
-        a: {
-          id: 'a',
-          elementId: 'a',
-          stroke: getTransform({ rotate: 20 }),
-        },
+    describe('should return a context to setStroke', () => {
+      it('to set stroke', () => {
+        const context = createGraphNodeContext(
+          { a: getBElement({ id: 'a' }) },
+          10
+        )
+        context.setStroke('a', getTransform({ rotate: 20 }))
+        expect(context.getObjectMap()).toEqual({
+          a: {
+            id: 'a',
+            elementId: 'a',
+            stroke: getTransform({ rotate: 20 }),
+          },
+        })
+        context.setStroke('a', getTransform({ rotate: 50 }))
+        expect(context.getObjectMap()).toEqual({
+          a: {
+            id: 'a',
+            elementId: 'a',
+            stroke: getTransform({ rotate: 50 }),
+          },
+        })
       })
-      context.setStroke('a', getTransform({ rotate: 50 }))
-      expect(context.getObjectMap()).toEqual({
-        a: {
-          id: 'a',
-          elementId: 'a',
-          stroke: getTransform({ rotate: 50 }),
-        },
+      it('to set fill recursively', () => {
+        const context = createGraphNodeContext({}, 10)
+        const g1 = context.createObject('g')
+        const rect1 = context.createObject('rect', { parent: g1 })
+        context.setStroke(g1, getTransform({ rotate: 20 }))
+
+        expect(context.getObjectMap()).toEqual({
+          [g1]: {
+            id: g1,
+            tag: 'g',
+            stroke: getTransform({ rotate: 20 }),
+            create: true,
+          },
+          [rect1]: {
+            id: rect1,
+            tag: 'rect',
+            parent: g1,
+            stroke: getTransform({ rotate: 20 }),
+            create: true,
+          },
+        })
       })
     })
     describe('setAttributes', () => {

--- a/spec/utils/graphNodes/nodes/hideObject.spec.ts
+++ b/spec/utils/graphNodes/nodes/hideObject.spec.ts
@@ -1,0 +1,39 @@
+import { getTransform } from '/@/models'
+import * as target from '/@/utils/graphNodes/nodes/hideObject'
+
+describe('src/utils/graphNodes/nodes/hideObject.ts', () => {
+  describe('computation', () => {
+    it('should call setStroke of the context and return the object', () => {
+      const setFill = jest.fn()
+      const setStroke = jest.fn()
+      expect(
+        target.struct.computation(
+          { disabled: false, object: 'a' },
+          {} as any,
+          { setStroke, setFill } as any
+        )
+      ).toEqual({ object: 'a' })
+      expect(setStroke).toHaveBeenCalledWith(
+        'a',
+        getTransform({ scale: { x: 0, y: 1 } })
+      )
+      expect(setFill).toHaveBeenCalledWith(
+        'a',
+        getTransform({ scale: { x: 0, y: 1 } })
+      )
+    })
+    it('should do nohting if disabled is true', () => {
+      const setFill = jest.fn()
+      const setStroke = jest.fn()
+      expect(
+        target.struct.computation(
+          { disabled: true, object: 'a' },
+          {} as any,
+          { setStroke, setFill } as any
+        )
+      ).toEqual({ object: 'a' })
+      expect(setStroke).not.toHaveBeenCalled()
+      expect(setFill).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/elements/GraphNodeInputLabel.vue
+++ b/src/components/elements/GraphNodeInputLabel.vue
@@ -23,7 +23,7 @@ Copyright (C) 2021, Tomoya Komiyama.
       inputKey + (valueLabel && !isColor ? ` (${valueLabel})` : '')
     }}</text>
     <rect
-      v-if="isColor"
+      v-if="valueLabel && isColor"
       :x="width + 6"
       y="-6"
       width="12"

--- a/src/models/graphNode.ts
+++ b/src/models/graphNode.ts
@@ -100,6 +100,7 @@ export interface GraphNodes {
   set_transform: GraphNodeSetTransform
   set_fill: GraphNodeSetFill
   set_stroke: GraphNodeSetStroke
+  hide_object: GraphNodeHideObject
   clone_object: GraphNodeCloneObject
   circle_clone_object: GraphNodeCircleCloneObject
   create_object_group: GraphNodeCreateObjectGroup
@@ -229,6 +230,14 @@ export interface GraphNodeSetStroke extends GraphNodeBase {
   inputs: {
     object: GraphNodeInput<string>
     color: GraphNodeInput<Transform>
+  }
+}
+
+export interface GraphNodeHideObject extends GraphNodeBase {
+  type: 'hide_object'
+  inputs: {
+    disabled: GraphNodeInput<boolean>
+    object: GraphNodeInput<string>
   }
 }
 

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -18,7 +18,7 @@ Copyright (C) 2021, Tomoya Komiyama.
 */
 
 import { getTransform, Transform } from '/@/models'
-import { clamp } from '/@/utils/geometry'
+import { circleClamp, clamp } from '/@/utils/geometry'
 
 export interface RGBA {
   r: number // 0 ~ 255
@@ -115,10 +115,11 @@ function getHsvToRgbParam(h: number, s: number, v: number, n: number) {
 }
 
 export function hsvaToRgba(hsva: HSVA): RGBA {
+  const h = circleClamp(0, 360, hsva.h)
   return {
-    r: clamp(0, 1, getHsvToRgbParam(hsva.h, hsva.s, hsva.v, 5)) * 255,
-    g: clamp(0, 1, getHsvToRgbParam(hsva.h, hsva.s, hsva.v, 3)) * 255,
-    b: clamp(0, 1, getHsvToRgbParam(hsva.h, hsva.s, hsva.v, 1)) * 255,
+    r: clamp(0, 1, getHsvToRgbParam(h, hsva.s, hsva.v, 5)) * 255,
+    g: clamp(0, 1, getHsvToRgbParam(h, hsva.s, hsva.v, 3)) * 255,
+    b: clamp(0, 1, getHsvToRgbParam(h, hsva.s, hsva.v, 1)) * 255,
     a: hsva.a,
   }
 }

--- a/src/utils/elements.ts
+++ b/src/utils/elements.ts
@@ -187,6 +187,15 @@ export function createGraphNodeContext(
     getGraphObject({ id: e.id, elementId: e.id })
   )
 
+  function execRecursively(parent: string, fn: (elm: GraphObject) => void) {
+    toList(graphElementMap)
+      .filter((elm) => elm.parent === parent)
+      .forEach((elm) => {
+        fn(elm)
+        execRecursively(elm.id, fn)
+      })
+  }
+
   return {
     setTransform(objectId, transform) {
       if (!graphElementMap[objectId]) return
@@ -199,10 +208,16 @@ export function createGraphNodeContext(
     setFill(objectId, transform) {
       if (!graphElementMap[objectId]) return
       graphElementMap[objectId].fill = transform
+      execRecursively(objectId, (elm) => {
+        this.setFill(elm.id, transform)
+      })
     },
     setStroke(objectId, transform) {
       if (!graphElementMap[objectId]) return
       graphElementMap[objectId].stroke = transform
+      execRecursively(objectId, (elm) => {
+        this.setStroke(elm.id, transform)
+      })
     },
     setAttributes(objectId, attributes, replace = false) {
       if (!graphElementMap[objectId]) return
@@ -229,11 +244,9 @@ export function createGraphNodeContext(
       graphElementMap[cloned.id] = cloned
 
       // clone children recursively
-      toList(graphElementMap)
-        .filter((elm) => elm.parent === src.id)
-        .forEach((elm) => {
-          this.cloneObject(elm.id, { parent: cloned.id })
-        })
+      execRecursively(objectId, (elm) => {
+        this.cloneObject(elm.id, { parent: cloned.id })
+      })
 
       return cloned.id
     },

--- a/src/utils/graphNodes/index.ts
+++ b/src/utils/graphNodes/index.ts
@@ -287,6 +287,7 @@ export const NODE_SUGGESTION_MENU_OPTIONS_SRC: {
     { label: '(<=) Number', type: 'less_than_or_equal', key: 'a' },
     { label: 'Make Vector2', type: 'make_vector2', key: 'x' },
     { label: 'Make Transform', type: 'make_transform', key: 'rotate' },
+    { label: 'Make Color', type: 'make_color', key: 'h' },
     { label: 'Polar Coord', type: 'polar_coord', key: 'rotate' },
     { label: 'Lerp Number', type: 'lerp_scaler', key: 'a' },
   ],

--- a/src/utils/graphNodes/index.ts
+++ b/src/utils/graphNodes/index.ts
@@ -61,6 +61,7 @@ import * as get_object from './nodes/getObject'
 import * as set_transform from './nodes/setTransform'
 import * as set_fill from './nodes/setFill'
 import * as set_stroke from './nodes/setStroke'
+import * as hide_object from './nodes/hideObject'
 import * as set_viewbox from './nodes/setViewbox'
 import * as clone_object from './nodes/cloneObject'
 import * as circle_clone_object from './nodes/circleCloneObject'
@@ -125,6 +126,7 @@ const NODE_MODULES: { [key in GraphNodeType]: NodeModule<any> } = {
   set_transform,
   set_fill,
   set_stroke,
+  hide_object,
   set_viewbox,
   clone_object,
   circle_clone_object,
@@ -242,6 +244,7 @@ export const NODE_MENU_OPTIONS_SRC: NODE_MENU_OPTION[] = [
       { label: 'Set Transform', type: 'set_transform' },
       { label: 'Set Fill', type: 'set_fill' },
       { label: 'Set Stroke', type: 'set_stroke' },
+      { label: 'Hide Object', type: 'hide_object' },
       { label: 'Set Viewbox', type: 'set_viewbox' },
       { label: 'Clone Object', type: 'clone_object' },
       { label: 'Circle Clone Object', type: 'circle_clone_object' },
@@ -302,6 +305,7 @@ export const NODE_SUGGESTION_MENU_OPTIONS_SRC: {
     { label: 'Set Transform', type: 'set_transform', key: 'object' },
     { label: 'Set Fill', type: 'set_fill', key: 'object' },
     { label: 'Set Stroke', type: 'set_stroke', key: 'object' },
+    { label: 'Hide Object', type: 'hide_object', key: 'object' },
     { label: 'Set Viewbox', type: 'set_viewbox', key: 'object' },
     { label: 'Clone Object', type: 'clone_object', key: 'object' },
     {

--- a/src/utils/graphNodes/nodes/hideObject.ts
+++ b/src/utils/graphNodes/nodes/hideObject.ts
@@ -1,0 +1,56 @@
+/*
+This file is part of Blendic SVG.
+
+Blendic SVG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Blendic SVG is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Blendic SVG.  If not, see <https://www.gnu.org/licenses/>.
+
+Copyright (C) 2021, Tomoya Komiyama.
+*/
+
+import { getTransform } from '/@/models'
+import { GraphNodeHideObject, GRAPH_VALUE_TYPE } from '/@/models/graphNode'
+import { createBaseNode, NodeStruct } from '/@/utils/graphNodes/core'
+
+export const struct: NodeStruct<GraphNodeHideObject> = {
+  create(arg = {}) {
+    return {
+      ...createBaseNode({
+        inputs: { disabled: { value: false }, object: { value: '' } },
+        ...arg,
+      }),
+      type: 'hide_object',
+    } as GraphNodeHideObject
+  },
+  data: {},
+  inputs: {
+    disabled: { type: GRAPH_VALUE_TYPE.BOOLEAN, default: false },
+    object: { type: GRAPH_VALUE_TYPE.OBJECT, default: '' },
+  },
+  outputs: {
+    object: GRAPH_VALUE_TYPE.OBJECT,
+  },
+  computation(inputs, _self, context): { object: string } {
+    if (!inputs.disabled) {
+      const color = getTransform({ scale: { x: 0, y: 1 } })
+      context.setStroke(inputs.object, color)
+      context.setFill(inputs.object, color)
+    }
+    return {
+      object: inputs.object,
+    }
+  },
+  width: 120,
+  color: '#dc143c',
+  textColor: '#fff',
+  label: 'Hide Object',
+}


### PR DESCRIPTION
fix #203 

- if `<g>` tag is set fill or stroke, the children of it are affected too
- fix: invalid color parsing
- feat: add new node to hide an object