### PR TITLE
fix: add essential attributes for `<svg>` to render `<use xlink:href=…

### DIFF
--- a/spec/utils/poseResolver.spec.ts
+++ b/spec/utils/poseResolver.spec.ts
@@ -47,6 +47,7 @@ import { posedColorAttributes } from '/@/utils/attributesResolver'
 import { mapReduce } from '/@/utils/commons'
 import { getConstraint } from '/@/utils/constraints'
 import {
+  addEssentialSvgAttributes,
   bakeKeyframe,
   bakeKeyframes,
   convertGroupUseTree,
@@ -850,6 +851,25 @@ describe('utils/poseResolver.ts', () => {
           },
         ],
       })
+    })
+  })
+
+  describe('addEssentialSvgAttributes', () => {
+    it('should add essential attributes of <svg>', () => {
+      expect(
+        addEssentialSvgAttributes(
+          getElementNode({ attributes: { fill: 'red' } })
+        )
+      ).toEqual(
+        addEssentialSvgAttributes(
+          getElementNode({
+            attributes: {
+              fill: 'red',
+              'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+            },
+          })
+        )
+      )
     })
   })
 })

--- a/src/composables/storage.ts
+++ b/src/composables/storage.ts
@@ -36,6 +36,7 @@ import {
   resolveAnimationGraph,
 } from '../utils/elements'
 import {
+  addEssentialSvgAttributes,
   bakeKeyframes,
   getGraphResolvedElementTree,
   getPosedElementTree,
@@ -153,6 +154,7 @@ export function useStorage() {
     const actor = elementStore.lastSelectedActor.value
     if (!armature || !actor) return
 
+    const svgTree = addEssentialSvgAttributes(actor.svgTree)
     const actionMap = animationStore.actionMap.value
     const actions = actionIds
       .filter((id) => actionMap[id])
@@ -162,7 +164,7 @@ export function useStorage() {
           getKeyframeMapByTargetId(action.keyframes),
           store.boneMap.value,
           toMap(actor.elements),
-          actor.svgTree,
+          svgTree,
           getLastFrame(action.keyframes)
         )
         return {
@@ -175,7 +177,7 @@ export function useStorage() {
       version: '1.0.0',
       appVersion: process.env.APP_VERSION ?? 'dev',
       actions,
-      svgTree: actor.svgTree,
+      svgTree,
     }
 
     saveJson(
@@ -193,10 +195,12 @@ export function useStorage() {
 
     const name = [action?.name, graph?.name].filter((n) => !!n).join('_')
 
-    const svgNode = getPosedElementTree(
-      animationStore.currentPosedBones.value,
-      toMap(actor.elements ?? []),
-      actor.svgTree
+    const svgNode = addEssentialSvgAttributes(
+      getPosedElementTree(
+        animationStore.currentPosedBones.value,
+        toMap(actor.elements ?? []),
+        actor.svgTree
+      )
     )
 
     let svg = svgNode

--- a/src/utils/poseResolver.ts
+++ b/src/utils/poseResolver.ts
@@ -711,3 +711,14 @@ function insertCreatedElements(
     ],
   }
 }
+
+export function addEssentialSvgAttributes(svg: ElementNode): ElementNode {
+  return {
+    ...svg,
+    attributes: {
+      ...svg.attributes,
+      // for <use xlink:href="#abc" />
+      'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+    },
+  }
+}


### PR DESCRIPTION
fix: add essential attributes for <svg> to render `<use xlink:href="#abc">`

- some browsers and GIMP require the attributes