### PR TITLE
fix: set created ids for the elements not having original ids 

### DIFF
--- a/spec/utils/elements.spec.ts
+++ b/spec/utils/elements.spec.ts
@@ -580,6 +580,23 @@ describe('utils/elements.ts', () => {
           }),
         })
       })
+      it('should set id pref', () => {
+        const context = createGraphNodeContext(
+          { a: getBElement({ id: 'a' }) },
+          10
+        )
+        context.cloneObject('a', {}, 'pre')
+        const ret = context.getObjectMap()
+
+        expect(ret).toEqual({
+          a: { id: 'a', elementId: 'a' },
+          pre_clone_0: {
+            id: 'pre_clone_0',
+            elementId: 'a',
+            clone: true,
+          },
+        })
+      })
       describe('when the target has children', () => {
         it('should clone nested created children', () => {
           const context = createGraphNodeContext({}, 10)
@@ -647,8 +664,66 @@ describe('utils/elements.ts', () => {
             parent: nested1.id,
           })
         })
+        it('should set id pref', () => {
+          const context = createGraphNodeContext({}, 10)
+
+          const parent = context.createObject('g')
+          const child1 = context.createObject('g', { parent })
+          const child2 = context.createObject('g', { parent: child1 })
+
+          context.cloneObject(parent, {}, 'pre')
+          const ret = context.getObjectMap()
+
+          delete ret[parent]
+          delete ret[child1]
+          delete ret[child2]
+
+          expect(ret).toEqual({
+            pre_clone_0: {
+              id: 'pre_clone_0',
+              tag: 'g',
+              create: true,
+            },
+            pre_clone_1: {
+              id: 'pre_clone_1',
+              tag: 'g',
+              create: true,
+              parent: 'pre_clone_0',
+            },
+            pre_clone_2: {
+              id: 'pre_clone_2',
+              tag: 'g',
+              create: true,
+              parent: 'pre_clone_1',
+            },
+          })
+        })
       })
     })
+
+    describe('should return a context to createCloneGroupObject', () => {
+      it('to create group object for cloning', () => {
+        const context = createGraphNodeContext(
+          { a: getBElement({ id: 'a' }) },
+          10
+        )
+        const id = context.createCloneGroupObject('a', { id: 'b' })
+        const ret = context.getObjectMap()
+
+        expect(id).toBe('b')
+        expect(ret).toEqual({
+          a: { id: 'a', elementId: 'a' },
+          b: {
+            id: 'b',
+            clone: false,
+            create: true,
+            elementId: 'a',
+            tag: 'g',
+          },
+        })
+      })
+    })
+
     describe('should return a context to createObject', () => {
       it('to create new object', () => {
         const context = createGraphNodeContext({}, 10)

--- a/spec/utils/elements.spec.ts
+++ b/spec/utils/elements.spec.ts
@@ -649,16 +649,29 @@ describe('utils/elements.ts', () => {
         })
       })
     })
-    it('should return a context to createObject', () => {
-      const context = createGraphNodeContext({}, 10)
-      const id = context.createObject('rect', { attributes: { x: 10 } })
-      const ret = context.getObjectMap()
+    describe('should return a context to createObject', () => {
+      it('to create new object', () => {
+        const context = createGraphNodeContext({}, 10)
+        const id = context.createObject('rect', { attributes: { x: 10 } })
+        const ret = context.getObjectMap()
 
-      expect(Object.values(ret)[0]).toEqual({
-        id,
-        create: true,
-        tag: 'rect',
-        attributes: { x: 10 },
+        expect(Object.values(ret)[0]).toEqual({
+          id,
+          create: true,
+          tag: 'rect',
+          attributes: { x: 10 },
+        })
+      })
+      it('extends id if it has been set', () => {
+        const context = createGraphNodeContext({}, 10)
+        context.createObject('rect', { id: 'a' })
+        const ret = context.getObjectMap()
+
+        expect(Object.values(ret)[0]).toEqual({
+          id: 'a',
+          create: true,
+          tag: 'rect',
+        })
       })
     })
   })

--- a/spec/utils/graphNodes/nodes/circleCloneObject.spec.ts
+++ b/spec/utils/graphNodes/nodes/circleCloneObject.spec.ts
@@ -24,7 +24,7 @@ describe('src/utils/graphNodes/nodes/circleCloneObject.ts', () => {
             radius: 10,
             fix_rotate: false,
           },
-          {} as any,
+          { id: 'b' } as any,
           {
             cloneObject,
             getTransform,
@@ -34,9 +34,21 @@ describe('src/utils/graphNodes/nodes/circleCloneObject.ts', () => {
         )
       ).toEqual({ origin: 'a', group: 'b' })
       expect(getTransform).toHaveBeenNthCalledWith(1, 'a')
-      expect(createCloneGroupObject).toHaveBeenNthCalledWith(1, 'a')
-      expect(cloneObject).toHaveBeenNthCalledWith(1, 'a', { parent: 'b' })
-      expect(cloneObject).toHaveBeenNthCalledWith(2, 'a', { parent: 'b' })
+      expect(createCloneGroupObject).toHaveBeenNthCalledWith(1, 'a', {
+        id: 'b',
+      })
+      expect(cloneObject).toHaveBeenNthCalledWith(
+        1,
+        'a',
+        { parent: 'b' },
+        'b_0'
+      )
+      expect(cloneObject).toHaveBeenNthCalledWith(
+        2,
+        'a',
+        { parent: 'b' },
+        'b_1'
+      )
       expect(setTransform).toHaveBeenNthCalledWith(
         1,
         '1',

--- a/spec/utils/graphNodes/nodes/cloneObject.spec.ts
+++ b/spec/utils/graphNodes/nodes/cloneObject.spec.ts
@@ -9,11 +9,11 @@ describe('src/utils/graphNodes/nodes/cloneObject.ts', () => {
           {
             object: 'a',
           },
-          {} as any,
+          { id: 'b' } as any,
           { cloneObject } as any
         )
       ).toEqual({ origin: 'a', clone: 'b' })
-      expect(cloneObject).toHaveBeenCalledWith('a')
+      expect(cloneObject).toHaveBeenCalledWith('a', {}, 'b')
     })
   })
 })

--- a/spec/utils/graphNodes/nodes/createObjectRect.spec.ts
+++ b/spec/utils/graphNodes/nodes/createObjectRect.spec.ts
@@ -39,13 +39,14 @@ describe('src/utils/graphNodes/nodes/createObjectRect.ts', () => {
             width: 4,
             height: 5,
           },
-          {} as any,
+          { id: 'a' } as any,
           { createObject } as any
         )
       ).toEqual({
         object: 'a',
       })
       expect(createObject).toHaveBeenCalledWith('rect', {
+        id: 'a',
         transform: getTransform({ rotate: 10 }),
         fill: getTransform({ rotate: 11 }),
         stroke: getTransform({ rotate: 12 }),

--- a/spec/utils/graphNodes/nodes/gridCloneObject.spec.ts
+++ b/spec/utils/graphNodes/nodes/gridCloneObject.spec.ts
@@ -25,7 +25,7 @@ describe('src/utils/graphNodes/nodes/gridCloneObject.ts', () => {
             width: 10,
             height: 20,
           },
-          {} as any,
+          { id: 'b' } as any,
           {
             cloneObject,
             getTransform,
@@ -35,9 +35,21 @@ describe('src/utils/graphNodes/nodes/gridCloneObject.ts', () => {
         )
       ).toEqual({ origin: 'a', group: 'b' })
       expect(getTransform).toHaveBeenNthCalledWith(1, 'a')
-      expect(createCloneGroupObject).toHaveBeenNthCalledWith(1, 'a')
-      expect(cloneObject).toHaveBeenNthCalledWith(1, 'a', { parent: 'b' })
-      expect(cloneObject).toHaveBeenNthCalledWith(2, 'a', { parent: 'b' })
+      expect(createCloneGroupObject).toHaveBeenNthCalledWith(1, 'a', {
+        id: 'b',
+      })
+      expect(cloneObject).toHaveBeenNthCalledWith(
+        1,
+        'a',
+        { parent: 'b' },
+        'b_0_0'
+      )
+      expect(cloneObject).toHaveBeenNthCalledWith(
+        2,
+        'a',
+        { parent: 'b' },
+        'b_0_1'
+      )
       expect(setTransform).toHaveBeenNthCalledWith(
         1,
         '1',

--- a/spec/utils/poseResolver.spec.ts
+++ b/spec/utils/poseResolver.spec.ts
@@ -536,7 +536,7 @@ describe('utils/poseResolver.ts', () => {
               {
                 id: 'a',
                 tag: '',
-                attributes: { 'data-blendic-use-origin-id': 'a' },
+                attributes: { 'data-blendic-use-origin-id': 'a', id: 'a' },
                 children: [],
               },
             ],
@@ -592,7 +592,7 @@ describe('utils/poseResolver.ts', () => {
               {
                 id: 'a',
                 tag: 'rect',
-                attributes: { 'data-blendic-use-origin-id': 'a' },
+                attributes: { 'data-blendic-use-origin-id': 'a', id: 'a' },
                 children: [],
               },
             ],
@@ -642,6 +642,7 @@ describe('utils/poseResolver.ts', () => {
         id: 'a',
         tag: 'rect',
         attributes: {
+          id: 'a',
           'data-blendic-use-origin-id': 'a',
           class: 'foo',
         },

--- a/src/components/elements/atoms/NativeElement.vue
+++ b/src/components/elements/atoms/NativeElement.vue
@@ -89,6 +89,7 @@ const NativeElement: any = defineComponent({
           ...(overrideAttrs.value ?? {}),
         }),
         onClick,
+        key: props.element.id,
       }
     })
 

--- a/src/utils/elements.ts
+++ b/src/utils/elements.ts
@@ -316,7 +316,8 @@ export function createGraphNodeContext(
       return group.id
     },
     createObject(tag, arg = {}) {
-      const created = getGraphObject({ ...arg, tag, create: true }, true)
+      // genereate new id if it has not been set
+      const created = getGraphObject({ ...arg, tag, create: true }, !arg.id)
       addElement(created)
       return created.id
     },

--- a/src/utils/graphNodes/core.ts
+++ b/src/utils/graphNodes/core.ts
@@ -117,11 +117,13 @@ export const nodeToCreateObjectProps = {
       [key in keyof GraphNodeCreateObjectInputsBase]: Required<
         GraphNodeCreateObjectInputsBase[key]
       >['value']
-    }
-  ): Omit<typeof inputs, 'disabled'> | undefined {
+    },
+    self: { id: string }
+  ): (Omit<typeof inputs, 'disabled'> & { id: string }) | undefined {
     return inputs.disabled
       ? undefined
       : {
+          id: self.id,
           parent: inputs.parent,
           transform: inputs.transform,
           fill: inputs.fill,

--- a/src/utils/graphNodes/core.ts
+++ b/src/utils/graphNodes/core.ts
@@ -70,7 +70,7 @@ export interface NodeContext<T> {
   ) => void
   getFrame: () => number
   getObjectMap: () => { [id: string]: T }
-  cloneObject: (objectId: string, arg?: Partial<T>) => string
+  cloneObject: (objectId: string, arg?: Partial<T>, idPref?: string) => string
   createCloneGroupObject: (objectId: string, arg?: Partial<T>) => string
   createObject: (tag: string, arg?: Partial<T>) => string
 }

--- a/src/utils/graphNodes/nodes/circleCloneObject.ts
+++ b/src/utils/graphNodes/nodes/circleCloneObject.ts
@@ -54,19 +54,23 @@ export const struct: NodeStruct<GraphNodeCircleCloneObject> = {
     origin: GRAPH_VALUE_TYPE.OBJECT,
     group: GRAPH_VALUE_TYPE.OBJECT,
   },
-  computation(inputs, _self, context): { origin: string; group: string } {
+  computation(inputs, self, context): { origin: string; group: string } {
     if (!inputs.object) return { origin: '', group: '' }
     const count = Math.floor(inputs.count)
     if (count <= 0) return { origin: inputs.object, group: '' }
 
-    const group = context.createCloneGroupObject(inputs.object)
+    const group = context.createCloneGroupObject(inputs.object, { id: self.id })
     const originTransform = context.getTransform(inputs.object)
 
     const angles = [...Array(count)].map((_, i) => (i * 360) / count)
     const baseV = { x: inputs.radius, y: 0 }
 
-    angles.forEach((angle) => {
-      const clone = context.cloneObject(inputs.object, { parent: group })
+    angles.forEach((angle, i) => {
+      const clone = context.cloneObject(
+        inputs.object,
+        { parent: group },
+        `${self.id}_${i}`
+      )
       const t = getTransform({
         translate: rotate(baseV, ((angle + inputs.rotate) * Math.PI) / 180),
         rotate: inputs.fix_rotate ? 0 : angle,

--- a/src/utils/graphNodes/nodes/cloneObject.ts
+++ b/src/utils/graphNodes/nodes/cloneObject.ts
@@ -38,8 +38,8 @@ export const struct: NodeStruct<GraphNodeCloneObject> = {
     origin: GRAPH_VALUE_TYPE.OBJECT,
     clone: GRAPH_VALUE_TYPE.OBJECT,
   },
-  computation(inputs, _self, context): { origin: string; clone: string } {
-    const clone = context.cloneObject(inputs.object)
+  computation(inputs, self, context): { origin: string; clone: string } {
+    const clone = context.cloneObject(inputs.object, {}, self.id)
     return { origin: inputs.object, clone }
   },
   width: 140,

--- a/src/utils/graphNodes/nodes/createObjectEllipse.ts
+++ b/src/utils/graphNodes/nodes/createObjectEllipse.ts
@@ -53,8 +53,8 @@ export const struct: NodeStruct<GraphNodeCreateObjectEllipse> = {
     ry: { type: GRAPH_VALUE_TYPE.SCALER, default: 10 },
   },
   outputs: nodeToCreateObjectProps.outputs,
-  computation(inputs, _self, context): { object: string } {
-    const base = nodeToCreateObjectProps.computation(inputs)
+  computation(inputs, self, context): { object: string } {
+    const base = nodeToCreateObjectProps.computation(inputs, self)
     if (!base) return { object: '' }
 
     return {

--- a/src/utils/graphNodes/nodes/createObjectPath.ts
+++ b/src/utils/graphNodes/nodes/createObjectPath.ts
@@ -47,8 +47,8 @@ export const struct: NodeStruct<GraphNodeCreateObjectPath> = {
     d: { type: GRAPH_VALUE_TYPE.D, default: [] },
   },
   outputs: nodeToCreateObjectProps.outputs,
-  computation(inputs, _self, context): { object: string } {
-    const base = nodeToCreateObjectProps.computation(inputs)
+  computation(inputs, self, context): { object: string } {
+    const base = nodeToCreateObjectProps.computation(inputs, self)
     if (!base) return { object: '' }
 
     return {

--- a/src/utils/graphNodes/nodes/createObjectRect.ts
+++ b/src/utils/graphNodes/nodes/createObjectRect.ts
@@ -55,8 +55,8 @@ export const struct: NodeStruct<GraphNodeCreateObjectRect> = {
     height: { type: GRAPH_VALUE_TYPE.SCALER, default: 100 },
   },
   outputs: nodeToCreateObjectProps.outputs,
-  computation(inputs, _self, context): { object: string } {
-    const base = nodeToCreateObjectProps.computation(inputs)
+  computation(inputs, self, context): { object: string } {
+    const base = nodeToCreateObjectProps.computation(inputs, self)
     if (!base) return { object: '' }
 
     return {

--- a/src/utils/graphNodes/nodes/createObjectText.ts
+++ b/src/utils/graphNodes/nodes/createObjectText.ts
@@ -59,8 +59,8 @@ export const struct: NodeStruct<GraphNodeCreateObjectText> = {
     'font-size': { type: GRAPH_VALUE_TYPE.SCALER, default: 100 },
   },
   outputs: nodeToCreateObjectProps.outputs,
-  computation(inputs, _self, context): { object: string } {
-    const base = nodeToCreateObjectProps.computation(inputs)
+  computation(inputs, self, context): { object: string } {
+    const base = nodeToCreateObjectProps.computation(inputs, self)
     if (!base) return { object: '' }
 
     return {

--- a/src/utils/graphNodes/nodes/gridCloneObject.ts
+++ b/src/utils/graphNodes/nodes/gridCloneObject.ts
@@ -55,14 +55,14 @@ export const struct: NodeStruct<GraphNodeGridCloneObject> = {
     origin: GRAPH_VALUE_TYPE.OBJECT,
     group: GRAPH_VALUE_TYPE.OBJECT,
   },
-  computation(inputs, _self, context): { origin: string; group: string } {
+  computation(inputs, self, context): { origin: string; group: string } {
     if (!inputs.object) return { origin: '', group: '' }
 
     const row = Math.floor(inputs.row)
     const column = Math.floor(inputs.column)
     if (row <= 0 || column <= 0) return { origin: 'a', group: '' }
 
-    const group = context.createCloneGroupObject(inputs.object)
+    const group = context.createCloneGroupObject(inputs.object, { id: self.id })
     const originTransform = context.getTransform(inputs.object)
 
     const diff = inputs.centered
@@ -76,9 +76,13 @@ export const struct: NodeStruct<GraphNodeGridCloneObject> = {
     const columns = [...Array(column)].map((_, i) => i * inputs.width)
     const rad = (inputs.rotate * Math.PI) / 180
 
-    rows.forEach((y) => {
-      columns.forEach((x) => {
-        const clone = context.cloneObject(inputs.object, { parent: group })
+    rows.forEach((y, i) => {
+      columns.forEach((x, j) => {
+        const clone = context.cloneObject(
+          inputs.object,
+          { parent: group },
+          `${self.id}_${i}_${j}`
+        )
         const t = getTransform({
           translate: rotate(diff ? sub({ x, y }, diff) : { x, y }, rad),
         })

--- a/src/utils/poseResolver.ts
+++ b/src/utils/poseResolver.ts
@@ -622,7 +622,12 @@ function convertUseElement(
             {
               id: node.id,
               tag: node.tag,
-              attributes: { ...attributes, [DATA_CLONE_ORIGIN_KEY]: node.id },
+              attributes: {
+                ...attributes,
+                [DATA_CLONE_ORIGIN_KEY]: node.id,
+                // must have id attribute to be referred by <use> tags
+                id: node.id,
+              },
               children,
             },
           ],


### PR DESCRIPTION
- fix: set created ids for the elements not having original ids 
- refactor: let created graph objects inherit the ids of graph nodes
-  perf: use the same ids for each created or cloned graph objects to set the same key of components