### PR TITLE
Fix: Drop `totalFrame` property in `Action` model

### DIFF
--- a/src/composables/storage.ts
+++ b/src/composables/storage.ts
@@ -325,7 +325,7 @@ export function useStorage() {
       svgTree,
       actor.elements,
       attributesMapPerFrame,
-      action.totalFrame * (1000 / 60)
+      getLastFrame(keyframes) * (1000 / 60)
     )
     saveSvg(svgElm.outerHTML, `${name}.svg`)
   }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -37,7 +37,6 @@ export interface Transform {
 export interface Action {
   id: string
   name: string
-  totalFrame: number
   armatureId: string
   keyframes: string[]
 }
@@ -240,7 +239,6 @@ export function getAction(
   const id = generateId ? v4() : arg.id ?? ''
   return {
     name: '',
-    totalFrame: 60,
     armatureId: '',
     keyframes: [],
     ...arg,


### PR DESCRIPTION
refs: #330

- It was not used anywhere and doesn't have correct value