### PR TITLE
Thin out interval items having the same attrs in a row

### DIFF
--- a/spec/utils/commons.spec.ts
+++ b/spec/utils/commons.spec.ts
@@ -50,6 +50,7 @@ import {
   shallowEqual,
   xor,
   getEntries,
+  thinOutSameItems,
 } from '/@/utils/commons'
 
 describe('utils/commons.ts', () => {
@@ -598,6 +599,44 @@ describe('utils/commons.ts', () => {
     })
     it('should ignore lastKey if the value for it does not exist', () => {
       expect(getEntries(obj, 'd')).toEqual(Object.entries(obj))
+    })
+  })
+
+  describe('thinOutSameItems', () => {
+    it('should thin out interval items having the same attrs in a row', () => {
+      expect(thinOutSameItems([...Array(1)].map(() => ({ a: '1' })))).toEqual([
+        { a: '1' },
+      ])
+      expect(thinOutSameItems([...Array(2)].map(() => ({ a: '1' })))).toEqual([
+        { a: '1' },
+        { a: '1' },
+      ])
+      expect(thinOutSameItems([...Array(3)].map(() => ({ a: '1' })))).toEqual([
+        { a: '1' },
+        undefined,
+        { a: '1' },
+      ])
+      expect(thinOutSameItems([...Array(4)].map(() => ({ a: '1' })))).toEqual([
+        { a: '1' },
+        undefined,
+        undefined,
+        { a: '1' },
+      ])
+      expect(thinOutSameItems([{ a: '1' }, { b: '1' }, { a: '1' }])).toEqual([
+        { a: '1' },
+        { b: '1' },
+        { a: '1' },
+      ])
+    })
+    it('should not thin out items different from its sides', () => {
+      expect(thinOutSameItems([{ a: '1' }, { b: '1' }, { a: '1' }])).toEqual([
+        { a: '1' },
+        { b: '1' },
+        { a: '1' },
+      ])
+      expect(
+        thinOutSameItems([{ a: '1' }, { a: '1', b: '1' }, { a: '1' }])
+      ).toEqual([{ a: '1' }, { a: '1', b: '1' }, { a: '1' }])
     })
   })
 })

--- a/spec/utils/svgMaker.spec.ts
+++ b/spec/utils/svgMaker.spec.ts
@@ -168,7 +168,7 @@ describe('utils/svgMaker.ts', () => {
       )
     })
     it('should return empty string if no keyframe exists', () => {
-      expect(createAnimationKeyframes('elm', [{}, {}])).toBe('')
+      expect(createAnimationKeyframes('elm', [{}, undefined, {}])).toBe('')
     })
   })
 
@@ -180,6 +180,7 @@ describe('utils/svgMaker.ts', () => {
     })
     it('should return empty string if no attribute exists', () => {
       expect(createAnimationKeyframeItem({}, 10)).toBe('')
+      expect(createAnimationKeyframeItem(undefined, 10)).toBe('')
     })
   })
 

--- a/spec/utils/svgMaker.spec.ts
+++ b/spec/utils/svgMaker.spec.ts
@@ -119,7 +119,24 @@ describe('utils/svgMaker.ts', () => {
 
       expect(svg).toBeInstanceOf(SVGElement)
       expect(svg.id).toBe('svg_1')
-      expect(svg.getElementsByTagName('style')).toBeTruthy()
+      expect(svg.getElementsByTagName('style')[0].innerHTML).toContain('#svg_1')
+      expect(svg.getElementsByTagName('style')[0].innerHTML).toContain('#g_1')
+    })
+    it('should omit styles for elements not having keyframes', () => {
+      const svg = serializeToAnimatedSvg(
+        getElementNode({
+          id: 'svg_1',
+          tag: 'svg',
+          children: [],
+        }),
+        ['svg_1'],
+        [{ svg_1: {} }, { svg_1: {} }],
+        2000
+      )
+
+      expect(svg.getElementsByTagName('style')[0].innerHTML).not.toContain(
+        '#svg_1'
+      )
     })
   })
 
@@ -137,6 +154,22 @@ describe('utils/svgMaker.ts', () => {
         '@keyframes blendic-keyframes-elm {0%{width:0;} 25%{width:10px;} 50%{width:20px;} 75%{width:30px;} 100%{width:100px;}}'
       )
     })
+    it('should omit empty keyframes', () => {
+      expect(
+        createAnimationKeyframes('elm', [
+          { width: '0' },
+          {},
+          { width: '20px' },
+          {},
+          { width: '100px' },
+        ])
+      ).toBe(
+        '@keyframes blendic-keyframes-elm {0%{width:0;} 50%{width:20px;} 100%{width:100px;}}'
+      )
+    })
+    it('should return empty string if no keyframe exists', () => {
+      expect(createAnimationKeyframes('elm', [{}, {}])).toBe('')
+    })
   })
 
   describe('createAnimationKeyframeItem', () => {
@@ -144,6 +177,9 @@ describe('utils/svgMaker.ts', () => {
       expect(createAnimationKeyframeItem({ width: '100px' }, 10)).toBe(
         '10%{width:100px;}'
       )
+    })
+    it('should return empty string if no attribute exists', () => {
+      expect(createAnimationKeyframeItem({}, 10)).toBe('')
     })
   })
 

--- a/src/utils/commons.ts
+++ b/src/utils/commons.ts
@@ -389,3 +389,24 @@ export function getEntries<T>(map: IdMap<T>, lastKey?: string): KeyValueMap<T> {
   }
   return Object.entries(map)
 }
+
+export function thinOutSameItems<T extends { [key: string]: unknown }>(
+  itemList: T[]
+): (T | undefined)[] {
+  const toBeThinnedIndexes = new Set()
+  let currentInfo: { item: T; from: number } | undefined
+
+  itemList.forEach((item, index) => {
+    if (!currentInfo || !hasSameProps(currentInfo.item, item)) {
+      currentInfo = { item, from: index }
+    } else {
+      if (currentInfo.from + 1 < index) {
+        toBeThinnedIndexes.add(index - 1)
+      }
+    }
+  })
+
+  return itemList.map((item, index) =>
+    toBeThinnedIndexes.has(index) ? undefined : item
+  )
+}

--- a/src/utils/svgMaker.ts
+++ b/src/utils/svgMaker.ts
@@ -18,6 +18,7 @@ Copyright (C) 2021, Tomoya Komiyama.
 */
 
 import { ElementNode, ElementNodeAttributes, IdMap } from '/@/models'
+import { thinOutSameItems } from '/@/utils/commons'
 import { isPlainText } from '/@/utils/elements'
 import { normalizeAttributes } from '/@/utils/helpers'
 
@@ -98,7 +99,9 @@ export function serializeToAnimatedSvg(
     .map((id) => {
       return createAnimationStyle(
         id,
-        attributesMapPerFrame.map((attrMap) => attrMap[id] ?? {}),
+        thinOutSameItems(
+          attributesMapPerFrame.map((attrMap) => attrMap[id] ?? {})
+        ),
         duration
       )
     })
@@ -110,7 +113,7 @@ export function serializeToAnimatedSvg(
 
 function createAnimationStyle(
   id: string,
-  attrsPerFrame: ElementNodeAttributes[],
+  attrsPerFrame: (ElementNodeAttributes | undefined)[],
   duration: number
 ): string {
   const keyframeStyle = createAnimationKeyframes(id, attrsPerFrame)
@@ -121,7 +124,7 @@ function createAnimationStyle(
 
 export function createAnimationKeyframes(
   id: string,
-  attrsPerFrame: ElementNodeAttributes[]
+  attrsPerFrame: (ElementNodeAttributes | undefined)[]
 ): string {
   const step = 100 / (attrsPerFrame.length - 1)
   const keyframeValues = attrsPerFrame
@@ -133,9 +136,11 @@ export function createAnimationKeyframes(
 }
 
 export function createAnimationKeyframeItem(
-  attrs: ElementNodeAttributes,
+  attrs: ElementNodeAttributes | undefined,
   percent: number
 ): string {
+  if (!attrs) return ''
+
   const content = Object.entries(attrs)
     .map(([key, value]) => `${key}:${value};`)
     .join('')

--- a/src/utils/svgMaker.ts
+++ b/src/utils/svgMaker.ts
@@ -113,10 +113,10 @@ function createAnimationStyle(
   attrsPerFrame: ElementNodeAttributes[],
   duration: number
 ): string {
-  return (
-    createAnimationKeyframes(id, attrsPerFrame) +
-    createAnimationElementStyle(id, duration)
-  )
+  const keyframeStyle = createAnimationKeyframes(id, attrsPerFrame)
+  return keyframeStyle
+    ? keyframeStyle + createAnimationElementStyle(id, duration)
+    : ''
 }
 
 export function createAnimationKeyframes(
@@ -124,9 +124,12 @@ export function createAnimationKeyframes(
   attrsPerFrame: ElementNodeAttributes[]
 ): string {
   const step = 100 / (attrsPerFrame.length - 1)
-  return `@keyframes ${getAnimationName(id)} {${attrsPerFrame
+  const keyframeValues = attrsPerFrame
     .map((a, i) => createAnimationKeyframeItem(a, step * i))
-    .join(' ')}}`
+    .filter((s) => s)
+  return keyframeValues.length > 0
+    ? `@keyframes ${getAnimationName(id)} {${keyframeValues.join(' ')}}`
+    : ''
 }
 
 export function createAnimationKeyframeItem(
@@ -136,7 +139,7 @@ export function createAnimationKeyframeItem(
   const content = Object.entries(attrs)
     .map(([key, value]) => `${key}:${value};`)
     .join('')
-  return `${percent}%{${content}}`
+  return content ? `${percent}%{${content}}` : ''
 }
 
 export function createAnimationElementStyle(


### PR DESCRIPTION
to reduce the size of exported animated SVG file.

e.g.
`[a, b, b, b, b, c, c]` -> `[a, b, undefined, undefined, b, c, c]`