### PR TITLE
Bake some attributes as `<animate>`

### DIFF
--- a/spec/utils/commons.spec.ts
+++ b/spec/utils/commons.spec.ts
@@ -676,5 +676,10 @@ describe('utils/commons.ts', () => {
         thinOutSameAttributes([...Array(4)].map(() => ({ a: '1' })))
       ).toEqual([{ a: '1' }, undefined, undefined, { a: '1' }])
     })
+    it('should deal undefined items', () => {
+      expect(
+        thinOutSameAttributes([{ a: '1' }, undefined, { a: '1' }])
+      ).toEqual([{ a: '1' }, undefined, { a: '1' }])
+    })
   })
 })

--- a/spec/utils/svgMaker.spec.ts
+++ b/spec/utils/svgMaker.spec.ts
@@ -100,69 +100,65 @@ describe('utils/svgMaker.ts', () => {
   })
 
   describe('serializeToAnimatedSvg', () => {
-    describe('should create SVG animate tags', () => {
-      it('except for transform', () => {
-        const svg = serializeToAnimatedSvg(
-          getElementNode({
-            id: 'svg_1',
-            tag: 'svg',
-            children: [
-              getElementNode({
-                id: 'g_1',
-                tag: 'g',
-                children: [],
-              }),
-            ],
-          }),
-          ['svg_1', 'g_1'],
-          [
-            { svg_1: { width: '0', transform: 'mock' }, g_1: { height: '0' } },
-            { svg_1: { width: '100px' }, g_1: { height: '200px' } },
+    it('should create SVG animate tags', () => {
+      const svg = serializeToAnimatedSvg(
+        getElementNode({
+          id: 'svg_1',
+          tag: 'svg',
+          children: [
+            getElementNode({
+              id: 'g_1',
+              tag: 'g',
+              children: [],
+            }),
           ],
-          2000
-        )
+        }),
+        ['svg_1', 'g_1'],
+        [
+          { svg_1: { width: '0', offset: 'mock' }, g_1: { offset: '0' } },
+          { svg_1: { width: '100px' }, g_1: { offset: '1' } },
+        ],
+        2000
+      )
 
-        expect(svg).toBeInstanceOf(SVGElement)
-        expect(svg.id).toBe('svg_1')
-        const animateG = svg.getElementsByClassName('blendic-anim-group')[0]
-        expect(animateG).toBeTruthy()
-        expect(animateG.innerHTML).toContain('#svg_1')
-        expect(animateG.innerHTML).toContain('width')
-        expect(animateG.innerHTML).toContain('#g_1')
-        expect(animateG.innerHTML).not.toContain('transform')
-      })
+      expect(svg).toBeInstanceOf(SVGElement)
+      expect(svg.id).toBe('svg_1')
+      const animateG = svg.getElementsByClassName('blendic-anim-group')[0]
+      expect(animateG).toBeTruthy()
+      expect(animateG.innerHTML).toContain('#svg_1')
+      expect(animateG.innerHTML).not.toContain('width')
+      expect(animateG.innerHTML).toContain('#g_1')
+      expect(animateG.innerHTML).toContain('offset')
     })
 
-    describe('should create animation styles', () => {
-      it('transform', () => {
-        const svg = serializeToAnimatedSvg(
-          getElementNode({
-            id: 'svg_1',
-            tag: 'svg',
-            children: [
-              getElementNode({
-                id: 'g_1',
-                tag: 'g',
-                children: [],
-              }),
-            ],
-          }),
-          ['svg_1', 'g_1'],
-          [
-            { svg_1: { width: '0' }, g_1: { transform: 'm(1,0,0,1,0,0)' } },
-            { svg_1: { width: '100px' }, g_1: { transform: 'm(2,0,0,1,0,0)' } },
+    it('should create animation styles', () => {
+      const svg = serializeToAnimatedSvg(
+        getElementNode({
+          id: 'svg_1',
+          tag: 'svg',
+          children: [
+            getElementNode({
+              id: 'g_1',
+              tag: 'g',
+              children: [],
+            }),
           ],
-          2000
-        )
+        }),
+        ['svg_1', 'g_1'],
+        [
+          { svg_1: { offset: '0' }, g_1: { transform: 'm(1,0,0,1,0,0)' } },
+          { svg_1: { offset: '1' }, g_1: { transform: 'm(2,0,0,1,0,0)' } },
+        ],
+        2000
+      )
 
-        expect(svg).toBeInstanceOf(SVGElement)
-        expect(svg.id).toBe('svg_1')
-        const style = svg.getElementsByTagName('style')[0]
-        expect(style.innerHTML).not.toContain('#svg_1')
-        expect(style.innerHTML).not.toContain('width')
-        expect(style.innerHTML).toContain('#g_1')
-        expect(style.innerHTML).toContain('transform')
-      })
+      expect(svg).toBeInstanceOf(SVGElement)
+      expect(svg.id).toBe('svg_1')
+      const style = svg.getElementsByTagName('style')[0]
+      expect(style.innerHTML).not.toContain('#svg_1')
+      expect(style.innerHTML).not.toContain('offset')
+      expect(style.innerHTML).toContain('#g_1')
+      expect(style.innerHTML).toContain('transform')
     })
   })
 
@@ -285,8 +281,8 @@ describe('utils/svgMaker.ts', () => {
         createAnimationTagsForElement(
           'elm',
           [
-            { d: 'M0,0', x: '10' },
-            { d: 'M0,4', x: '20' },
+            { d: 'M0,0', offset: '10' },
+            { d: 'M0,4', offset: '20' },
           ],
           1000
         )
@@ -304,7 +300,7 @@ describe('utils/svgMaker.ts', () => {
           `dur="1s"`,
           `href="#elm"`,
           `xlink:href="#elm"`,
-          `attributeName="x"`,
+          `attributeName="offset"`,
           `keyTimes="0;1"`,
           `values="10;20"`,
         ].join(' ')}/>`

--- a/spec/utils/svgMaker.spec.ts
+++ b/spec/utils/svgMaker.spec.ts
@@ -435,6 +435,36 @@ describe('utils/svgMaker.ts', () => {
       })
     })
 
+    describe('should merge and show only head SVG if showOnlyHead = true', () => {
+      it('case: b has unique children', () => {
+        expect(
+          mergeTwoElement(
+            getE({
+              children: [getE({ id: 'a_b_0' }), getE({ id: 'a_b_1' })],
+            }),
+            getE({
+              children: [
+                getE({ id: 'a_b_0' }),
+                getE({ id: 'b_0' }),
+                getE({ id: 'a_b_1' }),
+                getE({ id: 'b_1' }),
+              ],
+            }),
+            true
+          )
+        ).toEqual(
+          getE({
+            children: [
+              getE({ id: 'a_b_0' }),
+              getE({ id: 'b_0', attributes: { fill: 'none', stroke: 'none' } }),
+              getE({ id: 'a_b_1' }),
+              getE({ id: 'b_1', attributes: { fill: 'none', stroke: 'none' } }),
+            ],
+          })
+        )
+      })
+    })
+
     describe('when some children are plain text', () => {
       it('should pick text children in a', () => {
         expect(

--- a/src/composables/storage.ts
+++ b/src/composables/storage.ts
@@ -324,7 +324,7 @@ export function useStorage() {
     const svgTreeList = frames.map((_, currentFrame) =>
       getElementNodeAtFrame(currentFrame, endFrame)
     )
-    const wholeSvgElementNode = mergeSvgTreeList(svgTreeList)
+    const wholeSvgElementNode = mergeSvgTreeList(svgTreeList, true)
     if (!wholeSvgElementNode) return
 
     const wholeBElementMap = {
@@ -359,13 +359,9 @@ export function useStorage() {
         graphStore.nodeMap.value
       )
 
-      const existElements = toMap(flatElementTree([svgTreeList[currentFrame]]))
       const posedAttrsMap = attributesMapPerFrameByAction[currentFrame]
       return getGraphResolvedAttributesMap(
-        mapReduce(graphObjectMap, (gobj, id) =>
-          // Set disabled if the element doesn't appear at this frame
-          existElements[id] ? gobj : { ...gobj, disabled: true }
-        ),
+        graphObjectMap,
         mapReduce(originalAttributesMap, (attrs, id) => ({
           ...attrs,
           ...posedAttrsMap[id],

--- a/src/utils/commons.ts
+++ b/src/utils/commons.ts
@@ -413,16 +413,16 @@ export function thinOutSameItems<T>(
 }
 
 export function thinOutSameAttributes<T extends { [key: string]: unknown }>(
-  itemList: Partial<T>[]
+  itemList: (Partial<T> | undefined)[]
 ): (Partial<T> | undefined)[] {
   const allKeys: (keyof T)[] = Array.from(
-    new Set(itemList.flatMap((item) => Object.keys(item)))
+    new Set(itemList.flatMap((item) => (item ? Object.keys(item) : [])))
   )
 
   return allKeys
     .reduce<Partial<T>[]>(
       (p, key) => {
-        thinOutSameItems(itemList.map((item) => item[key])).forEach(
+        thinOutSameItems(itemList.map((item) => item?.[key])).forEach(
           (value, i) => {
             if (value) {
               p[i][key] = value

--- a/src/utils/svgMaker.ts
+++ b/src/utils/svgMaker.ts
@@ -384,7 +384,8 @@ function validAnimationAttr(key: string): boolean {
 }
 
 /**
- * It depends on each attribute whether the animation of CSS or SVG works well
+ * Some attributes don't work in CSS animation or SMIL animation.
+ * Since some browsers are not positive to support SMIL, use CSS as much as possible.
  */
 const VALID_ANIMATION_CSS_ATTR_KYES = new Set([
   'transform',
@@ -400,11 +401,7 @@ const VALID_ANIMATION_CSS_ATTR_KYES = new Set([
   'font-size',
   'text-anchor',
   'dominant-baseline',
-])
-const VALID_ANIMATION_ATTR_KYES = new Set([
-  'viewBox',
 
-  'd',
   'x',
   'y',
   'dx',
@@ -422,10 +419,10 @@ const VALID_ANIMATION_ATTR_KYES = new Set([
   'y1',
   'x2',
   'y2',
-  'offset',
 
   'gradientUnits',
   'spreadMethod',
   'stop-color',
   'stop-opacity',
 ])
+const VALID_ANIMATION_ATTR_KYES = new Set(['viewBox', 'd', 'offset'])


### PR DESCRIPTION
fix #339

- Some attributes, such as `viewBox`, `d`, etc., are not supported by CSS animation