### PR TITLE
fix: Invalid scaled bone appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add bone pickers at each bone selection field
+
+### Fixed
+- Fix invalid scale modification in the edit mode and the pose mode
 
 ## [0.17.0] - 2022-06-10
 ### Added

--- a/spec/composables/modeStates/appCanvas/poseMode/utils.spec.ts
+++ b/spec/composables/modeStates/appCanvas/poseMode/utils.spec.ts
@@ -21,6 +21,7 @@ import { getMockPoseCtx } from 'spec/composables/modeStates/appCanvas/mocks'
 import {
   getLastSelectedBoneSpace,
   handleToggleAxisGrid,
+  handleToggleAxisGridLocal,
 } from '/@/composables/modeStates/appCanvas/poseMode/utils'
 import { getBone, getTransform } from '/@/models'
 
@@ -106,6 +107,44 @@ describe('src/composables/modeStates/appCanvas/poseMode/utils.ts', () => {
       ctx.getAxisGridInfo.mockReturnValue({ ...val, local: true })
       handleToggleAxisGrid(ctx, 'y')
       expect(ctx.setAxisGridInfo).toHaveBeenNthCalledWith(3)
+    })
+  })
+
+  describe('handleToggleAxisGridLocal', () => {
+    it('x: should execute "setAxisGridInfo" to toggle axis "x"', () => {
+      const ctx = getMockPoseCtx()
+      const val = {
+        axis: 'x',
+        local: true,
+        vec: { x: 1, y: 0 },
+        origin: expect.anything(),
+      }
+
+      ctx.getAxisGridInfo.mockReturnValue(undefined)
+      handleToggleAxisGridLocal(ctx, 'x')
+      expect(ctx.setAxisGridInfo).toHaveBeenNthCalledWith(1, val)
+
+      ctx.getAxisGridInfo.mockReturnValue(val)
+      handleToggleAxisGridLocal(ctx, 'x')
+      expect(ctx.setAxisGridInfo).toHaveBeenNthCalledWith(2)
+    })
+
+    it('y: should execute "setAxisGridInfo" to toggle axis "y"', () => {
+      const ctx = getMockPoseCtx()
+      const val = {
+        axis: 'y',
+        local: true,
+        vec: { x: 0, y: 1 },
+        origin: expect.anything(),
+      }
+
+      ctx.getAxisGridInfo.mockReturnValue(undefined)
+      handleToggleAxisGridLocal(ctx, 'y')
+      expect(ctx.setAxisGridInfo).toHaveBeenNthCalledWith(1, val)
+
+      ctx.getAxisGridInfo.mockReturnValue(val)
+      handleToggleAxisGridLocal(ctx, 'y')
+      expect(ctx.setAxisGridInfo).toHaveBeenNthCalledWith(2)
     })
   })
 })

--- a/spec/utils/armatures.spec.ts
+++ b/spec/utils/armatures.spec.ts
@@ -64,6 +64,33 @@ describe('utils/armatures', () => {
     })
   })
 
+  describe('posedTransform', () => {
+    it('should apply pose transform', () => {
+      expect(
+        target.posedTransform(
+          getBone({
+            head: { x: 0, y: 0 },
+            tail: { x: 0, y: 10 },
+          }),
+          [
+            getTransform({
+              translate: { x: 10, y: 20 },
+              scale: { x: 4, y: 2 },
+            }),
+          ]
+        )
+      ).toEqual(
+        getBone({
+          head: { x: 10, y: 20 },
+          tail: { x: 10, y: 40 },
+          transform: getTransform({
+            scale: { x: 2, y: 1 },
+          }),
+        })
+      )
+    })
+  })
+
   describe('extrudeFromParent', () => {
     const parent = getBone({ id: 'parent', tail: { x: 1, y: 2 } })
 

--- a/src/composables/modeStates/appCanvas/poseMode/scalingState.ts
+++ b/src/composables/modeStates/appCanvas/poseMode/scalingState.ts
@@ -25,7 +25,7 @@ import {
 import { useDefaultState } from '/@/composables/modeStates/appCanvas/poseMode/defaultState'
 import {
   getDefaultEditTransform,
-  handleToggleAxisGrid,
+  handleToggleAxisGridLocal,
 } from '/@/composables/modeStates/appCanvas/poseMode/utils'
 import { getPosedBoneHeadsOrigin } from '/@/utils/armatures'
 import { mapReduce } from '/@/utils/commons'
@@ -82,11 +82,11 @@ const state: PoseState = {
           case 'Escape':
             return useDefaultState
           case 'x': {
-            handleToggleAxisGrid(ctx, 'x')
+            handleToggleAxisGridLocal(ctx, 'x')
             return
           }
           case 'y': {
-            handleToggleAxisGrid(ctx, 'y')
+            handleToggleAxisGridLocal(ctx, 'y')
             return
           }
           default:

--- a/src/composables/modeStates/appCanvas/poseMode/scalingState.ts
+++ b/src/composables/modeStates/appCanvas/poseMode/scalingState.ts
@@ -28,7 +28,7 @@ import {
   handleToggleAxisGrid,
 } from '/@/composables/modeStates/appCanvas/poseMode/utils'
 import { getPosedBoneHeadsOrigin } from '/@/utils/armatures'
-import { mapFilter, mapReduce } from '/@/utils/commons'
+import { mapReduce } from '/@/utils/commons'
 import { snapScale } from '/@/utils/geometry'
 
 export function useScalingState(): PoseState {
@@ -53,7 +53,6 @@ const state: PoseState = {
   handleEvent: async (ctx, event) => {
     switch (event.type) {
       case 'pointermove': {
-        const boneMap = ctx.getBones()
         const selectedBoneMap = ctx.getSelectedBones()
         const origin = getPosedBoneHeadsOrigin(selectedBoneMap)
         const scaleDiff = multi(
@@ -65,13 +64,9 @@ const state: PoseState = {
         const gridScale = event.data.ctrl ? snapScale(scaleDiff) : scaleDiff
         const snappedScale = snapScaleDiff(ctx, gridScale)
 
-        const targetIds = mapFilter(
-          selectedBoneMap,
-          (_, id) => boneMap[id] && !boneMap[id].connected
-        )
         const t = getDefaultEditTransform({ scale: snappedScale })
         ctx.setEditTransforms(
-          mapReduce(targetIds, () => t),
+          mapReduce(selectedBoneMap, () => t),
           'scale'
         )
         return

--- a/src/composables/modeStates/appCanvas/poseMode/utils.ts
+++ b/src/composables/modeStates/appCanvas/poseMode/utils.ts
@@ -87,6 +87,27 @@ export function handleToggleAxisGrid(
   }
 }
 
+export function handleToggleAxisGridLocal(
+  ctx: Pick<
+    PoseStateContext,
+    'getAxisGridInfo' | 'setAxisGridInfo' | 'getLastSelectedBoneId' | 'getBones'
+  >,
+  axis: AxisGrid
+) {
+  if (ctx.getAxisGridInfo()?.axis === axis) {
+    ctx.setAxisGridInfo()
+  } else {
+    const unitV = axis === 'x' ? { x: 1, y: 0 } : { x: 0, y: 1 }
+    const boneSpace = getLastSelectedBoneSpace(ctx)
+    ctx.setAxisGridInfo({
+      axis,
+      local: true,
+      vec: rotate(unitV, boneSpace.radian),
+      origin: boneSpace.origin,
+    })
+  }
+}
+
 export function getDefaultEditTransform(arg: Partial<Transform> = {}) {
   return getTransform({ scale: { x: 0, y: 0 }, ...arg })
 }

--- a/src/utils/armatures.ts
+++ b/src/utils/armatures.ts
@@ -177,9 +177,16 @@ export function posedTransform(bone: Bone, transforms: Transform[]): Bone {
     head,
     tail: add(multi(sub(tail, head), convoluted.scale.y), head),
     transform: getTransform({
-      // scale x does not affect bone's head and tail
-      // => it affects bone's width
-      scale: { x: convoluted.scale.x, y: 1 },
+      // Original bone's width is derived from its height: the distance between head and tail
+      // Scale x affects its width as well
+      // => Divide the width by scale y to negate the pose transformation of the height
+      scale: {
+        x:
+          convoluted.scale.y === 0
+            ? 0
+            : convoluted.scale.x / convoluted.scale.y,
+        y: 1,
+      },
     }),
   }
 }


### PR DESCRIPTION
[fix: Invalid scaled bone appearance](https://github.com/miyanokomiya/blendic-svg/commit/a5d7b4567f58c228aa240290d99fbe01637da597)
[fix: Connected bones' scale can be modified as well as their rotation](https://github.com/miyanokomiya/blendic-svg/commit/95f639fe3ee74774431cc31d889cd35cad1e4b34)
[fix: Allow pose scaling state to activate only local space grid](https://github.com/miyanokomiya/blendic-svg/commit/70f6c7d9e0787470b81c4db9b6724006805649f6)