### PR TITLE
fix: Invalid `viewBox` emulation in animated SVG

### DIFF
--- a/src/utils/svgMaker.ts
+++ b/src/utils/svgMaker.ts
@@ -234,8 +234,8 @@ function createTransformFromViewbox(viewBoxStr: string) {
     0,
     0,
     minScale,
-    paddingX - viewBox.x,
-    paddingY - viewBox.y,
+    paddingX - viewBox.x * minScale,
+    paddingY - viewBox.y * minScale,
   ])
 }
 


### PR DESCRIPTION
fix #511