### PR TITLE
feat: Change `animation-timing-function` to `step-start`

### DIFF
--- a/spec/components/atoms/__snapshots__/AnimatedSvgSettingDialog.spec.ts.snap
+++ b/spec/components/atoms/__snapshots__/AnimatedSvgSettingDialog.spec.ts.snap
@@ -59,6 +59,18 @@ exports[`src/components/molecules/dialogs/AnimatedSvgSettingDialog.vue snapshot 
                   class=""
                   type="button"
                 >
+                  5
+                </button>
+                <button
+                  class=""
+                  type="button"
+                >
+                  10
+                </button>
+                <button
+                  class=""
+                  type="button"
+                >
                   20
                 </button>
                 <button
@@ -74,6 +86,35 @@ exports[`src/components/molecules/dialogs/AnimatedSvgSettingDialog.vue snapshot 
                   60
                 </button>
                 
+              </div>
+              
+            </div>
+            
+          </div>
+          <div
+            class="row-block inline-field between"
+          >
+            
+            <label>
+              FPS(Custom)
+            </label>
+            <div
+              class="inline-content"
+            >
+              
+              <div
+                class="slider-wrapper inline-slider"
+              >
+                <div
+                  class="slider-background"
+                  style="transform: scaleX(0.4915254237288136);"
+                />
+                <input
+                  type="text"
+                />
+                <div
+                  class="slider-forward"
+                />
               </div>
               
             </div>

--- a/spec/utils/__snapshots__/poseResolver.spec.ts.snap
+++ b/spec/utils/__snapshots__/poseResolver.spec.ts.snap
@@ -3,12 +3,15 @@
 exports[`utils/poseResolver.ts bake bakeKeyframe json snapshot 1`] = `
 "{
  \\"root\\": {
-  \\"viewBox\\": \\"1 2 3 4\\"
+  \\"viewBox\\": \\"1 2 3 4\\",
+  \\"transform\\": \\"matrix(1,0,0,1,0,0)\\"
  },
  \\"elm_a\\": {
   \\"transform\\": \\"matrix(0.93969,0.34202,-0.34202,0.93969,0,0)\\"
  },
- \\"elm_b\\": {}
+ \\"elm_b\\": {
+  \\"transform\\": \\"matrix(1,0,0,1,0,0)\\"
+ }
 }"
 `;
 

--- a/spec/utils/helpers.spec.ts
+++ b/spec/utils/helpers.spec.ts
@@ -143,6 +143,21 @@ describe('utils/helpers.ts', () => {
         opacity: '0.1',
       })
     })
+
+    it('should drop identy transform', () => {
+      expect(
+        normalizeAttributes({
+          transform: 'matrix(1,0,0,1,0,0)',
+        })
+      ).toEqual({})
+      expect(
+        normalizeAttributes({
+          transform: 'matrix(1,0,0,1,1,0)',
+        })
+      ).toEqual({
+        transform: 'matrix(1,0,0,1,1,0)',
+      })
+    })
   })
 
   describe('getKeyframeBoneSummary', () => {

--- a/spec/utils/poseResolver.spec.ts
+++ b/spec/utils/poseResolver.spec.ts
@@ -230,13 +230,16 @@ describe('utils/poseResolver.ts', () => {
         )
         expect(Object.keys(res).sort()).toEqual(['0', '1', '2', '3', '4', '5'])
         expect(res[2]).toEqual({
-          root: { viewBox: '1 2 3 4' },
+          root: {
+            viewBox: '1 2 3 4',
+            transform: affineToTransformTruncated(IDENTITY_AFFINE),
+          },
           elm_a: {
             transform: affineToTransformTruncated(
               boneToAffine(getBone({ transform: getTransform({ rotate: 20 }) }))
             ),
           },
-          elm_b: {},
+          elm_b: { transform: affineToTransformTruncated(IDENTITY_AFFINE) },
         })
       })
     })
@@ -267,13 +270,16 @@ describe('utils/poseResolver.ts', () => {
         )
         expect(Object.keys(res).sort()).toEqual(['0', '1'])
         expect(res[1]).toEqual({
-          root: { viewBox: '1 2 3 4' },
+          root: {
+            viewBox: '1 2 3 4',
+            transform: affineToTransformTruncated(IDENTITY_AFFINE),
+          },
           elm_a: {
             transform: affineToTransformTruncated(
               boneToAffine(getBone({ transform: getTransform({ rotate: 20 }) }))
             ),
           },
-          elm_b: {},
+          elm_b: { transform: affineToTransformTruncated(IDENTITY_AFFINE) },
         })
       })
     })
@@ -377,13 +383,16 @@ describe('utils/poseResolver.ts', () => {
         expect(
           bakeKeyframe(keyMap, boneMap, constraintMap, elementMap, root, 2)
         ).toEqual({
-          root: { viewBox: '1 2 3 4' },
+          root: {
+            viewBox: '1 2 3 4',
+            transform: affineToTransformTruncated(IDENTITY_AFFINE),
+          },
           elm_a: {
             transform: affineToTransformTruncated(
               boneToAffine(getBone({ transform: getTransform({ rotate: 20 }) }))
             ),
           },
-          elm_b: {},
+          elm_b: { transform: affineToTransformTruncated(IDENTITY_AFFINE) },
         })
       })
       it('json snapshot', () => {
@@ -413,13 +422,16 @@ describe('utils/poseResolver.ts', () => {
             root
           )
         ).toEqual({
-          root: { viewBox: '1 2 3 4' },
+          root: {
+            viewBox: '1 2 3 4',
+            transform: affineToTransformTruncated(IDENTITY_AFFINE),
+          },
           elm_a: {
             transform: affineToTransformTruncated(
               boneToAffine(getBone({ transform: getTransform({ rotate: 20 }) }))
             ),
           },
-          elm_b: {},
+          elm_b: { transform: affineToTransformTruncated(IDENTITY_AFFINE) },
         })
       })
     })

--- a/spec/utils/svgMaker.spec.ts
+++ b/spec/utils/svgMaker.spec.ts
@@ -160,8 +160,8 @@ describe('utils/svgMaker.ts', () => {
           ],
         }),
         [
-          { svg_1: { offset: '0' }, g_1: { transform: 'm(1,0,0,1,0,0)' } },
-          { svg_1: { offset: '1' }, g_1: { transform: 'm(2,0,0,1,0,0)' } },
+          { svg_1: { offset: '0' }, g_1: { transform: 'matrix(1,0,0,1,0,0)' } },
+          { svg_1: { offset: '1' }, g_1: { transform: 'matrix(2,0,0,1,0,0)' } },
         ],
         2000,
         3
@@ -226,8 +226,8 @@ describe('utils/svgMaker.ts', () => {
           ],
         }),
         [
-          { svg_1: { offset: '1' }, g_1: { transform: 'm(2,0,0,1,0,0)' } },
-          { svg_1: { offset: '1' }, g_1: { transform: 'm(2,0,0,1,0,0)' } },
+          { svg_1: { offset: '1' }, g_1: { transform: 'matrix(2,0,0,1,0,0)' } },
+          { svg_1: { offset: '1' }, g_1: { transform: 'matrix(2,0,0,1,0,0)' } },
         ],
         2000,
         3
@@ -237,6 +237,38 @@ describe('utils/svgMaker.ts', () => {
       const style = svg.getElementsByTagName('style')[0]
       expect(style.innerHTML).not.toContain('offset')
       expect(style.innerHTML).not.toContain('transform')
+      expect(svg.innerHTML).toContain('transform')
+    })
+
+    it('should drop transform when an element has identy transform throughout the animation', () => {
+      const svg = serializeToAnimatedSvg(
+        'test',
+        getElementNode({
+          id: 'svg_1',
+          tag: 'svg',
+          children: [
+            getElementNode({
+              id: 'g_1',
+              tag: 'g',
+              children: [],
+            }),
+          ],
+        }),
+        [
+          {
+            svg_1: { transform: 'matrix(1,0,0,1,0,0)' },
+            g_1: { transform: 'matrix(1,0,0,1,0,0)' },
+          },
+          {
+            svg_1: { transform: 'matrix(1,0,0,1,0,0)' },
+            g_1: { transform: 'matrix(1,0,0,1,0,0)' },
+          },
+        ],
+        2000,
+        3
+      )
+
+      expect(svg.innerHTML).not.toContain('transform')
     })
 
     it('should complete edge animated attributes', () => {
@@ -255,8 +287,8 @@ describe('utils/svgMaker.ts', () => {
         }),
         [
           {},
-          { svg_1: { offset: '1' }, g_1: { transform: 'm(1,0,0,1,0,0)' } },
-          { svg_1: { offset: '2' }, g_1: { transform: 'm(2,0,0,1,0,0)' } },
+          { svg_1: { offset: '1' }, g_1: { transform: 'matrix(1,0,0,1,0,0)' } },
+          { svg_1: { offset: '2' }, g_1: { transform: 'matrix(2,0,0,1,0,0)' } },
           {},
         ],
         2000,
@@ -268,8 +300,8 @@ describe('utils/svgMaker.ts', () => {
       expect(animateG.innerHTML).toContain('keyTimes="0;0.25;0.5;1"')
       const style = svg.getElementsByTagName('style')[0]
       expect(style.innerHTML).not.toContain('offset')
-      expect(style.innerHTML).toContain('0%{transform:m(1')
-      expect(style.innerHTML).toContain('100%{transform:m(2')
+      expect(style.innerHTML).toContain('0%{transform:matrix(1')
+      expect(style.innerHTML).toContain('100%{transform:matrix(2')
     })
 
     it('should not add animated identifier to elements not having any animated attributes', () => {

--- a/spec/utils/svgMaker.spec.ts
+++ b/spec/utils/svgMaker.spec.ts
@@ -175,7 +175,7 @@ describe('utils/svgMaker.ts', () => {
       expect(style.innerHTML).toContain(svg.children[0].classList.value)
       expect(style.innerHTML).toContain('transform')
       expect(style.innerHTML).toContain(
-        '.test-0 * {animation-duration:2s;animation-iteration-count:3;animation-timing-function:linear;}'
+        '.test-0 * {animation-duration:2s;animation-iteration-count:3;animation-timing-function:step-start;}'
       )
     })
 

--- a/src/components/molecules/dialogs/AnimatedSvgSettingDialog.vue
+++ b/src/components/molecules/dialogs/AnimatedSvgSettingDialog.vue
@@ -29,6 +29,15 @@ Copyright (C) 2022, Tomoya Komiyama.
               :options="fpsOptions"
             />
           </InlineField>
+          <InlineField label="FPS(Custom)" between>
+            <SliderInput
+              v-model="draftSettings.fps"
+              :min="1"
+              :max="60"
+              integer
+              class="inline-slider"
+            />
+          </InlineField>
           <InlineField label="Range" between>
             <ToggleRadioButtons
               v-model="draftSettings.range"
@@ -124,7 +133,7 @@ const emits = defineEmits<{
   (e: 'execute', settings: AnimationExportingSettings): void
 }>()
 
-const fpsOptions = [20, 30, 60].map((value) => ({
+const fpsOptions = [5, 10, 20, 30, 60].map((value) => ({
   value,
   label: `${value}`,
 }))

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -118,6 +118,22 @@ export function toStyle(obj: { [name: string]: string | undefined }): string {
 export function normalizeAttributes(
   attributes: ElementNodeAttributes
 ): ElementNodeAttributes {
+  return normalizeAttributeTransform(normalizeAttributeColor(attributes))
+}
+
+function normalizeAttributeTransform(
+  attributes: ElementNodeAttributes
+): ElementNodeAttributes {
+  if (attributes.transform !== 'matrix(1,0,0,1,0,0)') return attributes
+
+  const ret = { ...attributes }
+  delete ret.transform
+  return ret
+}
+
+function normalizeAttributeColor(
+  attributes: ElementNodeAttributes
+): ElementNodeAttributes {
   if (!attributes.fill && !attributes.stroke) return attributes
 
   return {

--- a/src/utils/poseResolver.ts
+++ b/src/utils/poseResolver.ts
@@ -47,11 +47,7 @@ import {
 } from '/@/utils/attributesResolver'
 import { BoneConstraint } from '/@/utils/constraints'
 import { flatElementTree, isPlainText } from '/@/utils/elements'
-import {
-  isIdentityAffine,
-  logRoundByDigit,
-  transformToAffine,
-} from '/@/utils/geometry'
+import { logRoundByDigit, transformToAffine } from '/@/utils/geometry'
 import { splitKeyframeMapByName } from '/@/utils/keyframes'
 import { getInterpolatedTransformMapByTargetId } from '/@/utils/keyframes/keyframeBone'
 import * as keyframeConstraint from '/@/utils/keyframes/keyframeConstraint'
@@ -169,7 +165,7 @@ function getPosedAttributes(
     element,
     node
   )
-  if (matrix && !isIdentityAffine(matrix)) {
+  if (matrix) {
     ret.transform = affineToTransformTruncated(matrix)
   }
 

--- a/src/utils/svgMaker.ts
+++ b/src/utils/svgMaker.ts
@@ -210,7 +210,7 @@ export function serializeToAnimatedSvg(
       .join('') +
     `.${identifierMap[adjustedSvgRoot.id]} * {animation-duration:${
       duration / 1000
-    }s;animation-iteration-count:${iteration};animation-timing-function:linear;}`
+    }s;animation-iteration-count:${iteration};animation-timing-function:step-start;}`
 
   const staticAttributeOwnerIds = new Set([
     ...animTagMap.keys(),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20733354/188296839-1ed374e4-3eef-497d-adfd-4d9b6415d920.png)

[fix: Stop dropping identity transformation](https://github.com/miyanokomiya/blendic-svg/commit/845647a71786a6ff25dd82ad0df53908665730ad)
- It's essential for animated SVG
=> CSS animation applies previous attribute when current attribute doesn't exist

![boxing-anim (3)](https://user-images.githubusercontent.com/20733354/188296871-8f5c751d-5606-469a-b44b-e371f98738bf.svg)
![jump-anim (4)](https://user-images.githubusercontent.com/20733354/188296883-8506ae20-63c9-47b3-ba0e-db173eea0693.svg)
