### PR TITLE
feat: Make animated SVG size flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix: Disable SMIL interpolation like CSS animation
+- Fix: Inaccurate animation duration
 
 ## [0.17.4] - 2022-07-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Make animated SVG size flexible
+- Add new config UI for choosing interpolation type
+
+### Fixed
+- Fix: Disable SMIL interpolation like CSS animation
 
 ## [0.17.4] - 2022-07-30
 ### Added

--- a/spec/utils/svgMaker.spec.ts
+++ b/spec/utils/svgMaker.spec.ts
@@ -209,36 +209,74 @@ describe('utils/svgMaker.ts', () => {
       expect(animateG.innerHTML).not.toContain('calcMode="discrete"')
     })
 
-    it('should translate viewBox to transform', () => {
-      const svg = serializeToAnimatedSvg(
-        'test',
-        getElementNode({
-          id: 'svg_1',
-          tag: 'svg',
-          attributes: { viewBox: '0 0 100 100' },
-          children: [
-            getElementNode({
-              id: 'g_1',
-              tag: 'g',
-              children: [],
-            }),
+    describe('should convert viewBox to transform', () => {
+      it('Use fixed size when "size" is not elaborated', () => {
+        const svg = serializeToAnimatedSvg(
+          'test',
+          getElementNode({
+            id: 'svg_1',
+            tag: 'svg',
+            attributes: { viewBox: '0 0 100 100' },
+            children: [
+              getElementNode({
+                id: 'g_1',
+                tag: 'g',
+                children: [],
+              }),
+            ],
+          }),
+          [
+            { svg_1: { viewBox: '0 0 100 100' } },
+            { svg_1: { viewBox: '0 0 50 50' } },
           ],
-        }),
-        [
-          { svg_1: { viewBox: '0 0 100 100' } },
-          { svg_1: { viewBox: '0 0 50 50' } },
-        ],
-        2000,
-        'infinite'
-      )
+          2000
+        )
 
-      expect(svg).toBeInstanceOf(SVGElement)
-      expect(svg.children[2].id).not.toBe('g_1')
-      expect(svg.children[2].children[0].tagName).toBe('g')
-      const style = svg.getElementsByTagName('style')[0]
-      expect(style.innerHTML).toContain('matrix(2,0,0,2,0,0)')
-      const animateG = svg.getElementsByClassName('blendic-anim-group')[0]
-      expect(animateG.innerHTML).not.toContain('viewBox')
+        expect(svg).toBeInstanceOf(SVGElement)
+        expect(svg.children[2].id).not.toBe('g_1')
+        expect(svg.children[2].children[0].tagName).toBe('g')
+        const style = svg.getElementsByTagName('style')[0]
+        expect(style.innerHTML).toContain('matrix(1,0,0,1,0,0)')
+        expect(style.innerHTML).toContain('matrix(2,0,0,2,0,0)')
+        const animateG = svg.getElementsByClassName('blendic-anim-group')[0]
+        expect(animateG.innerHTML).not.toContain('viewBox')
+      })
+
+      it('Use custom size when "size" is elaborated', () => {
+        const svg = serializeToAnimatedSvg(
+          'test',
+          getElementNode({
+            id: 'svg_1',
+            tag: 'svg',
+            attributes: { viewBox: '0 0 100 100' },
+            children: [
+              getElementNode({
+                id: 'g_1',
+                tag: 'g',
+                children: [],
+              }),
+            ],
+          }),
+          [
+            { svg_1: { viewBox: '0 0 100 100' } },
+            { svg_1: { viewBox: '0 0 50 50' } },
+          ],
+          2000,
+          undefined,
+          undefined,
+          undefined,
+          { width: 200, height: 100 }
+        )
+
+        expect(svg).toBeInstanceOf(SVGElement)
+        expect(svg.children[2].id).not.toBe('g_1')
+        expect(svg.children[2].children[0].tagName).toBe('g')
+        const style = svg.getElementsByTagName('style')[0]
+        expect(style.innerHTML).toContain('matrix(1,0,0,1,50,0)')
+        expect(style.innerHTML).toContain('matrix(2,0,0,2,50,0)')
+        const animateG = svg.getElementsByClassName('blendic-anim-group')[0]
+        expect(animateG.innerHTML).not.toContain('viewBox')
+      })
     })
 
     it('should not animate static attributes', () => {

--- a/src/composables/settings.ts
+++ b/src/composables/settings.ts
@@ -17,6 +17,7 @@ along with Blendic SVG.  If not, see <https://www.gnu.org/licenses/>.
 Copyright (C) 2021, Tomoya Komiyama.
 */
 
+import type { Size } from 'okanvas'
 import { reactive, watchEffect } from 'vue'
 
 export interface AnimationExportingSettings {
@@ -25,7 +26,7 @@ export interface AnimationExportingSettings {
   range: 'auto' | 'custom'
   customRange: { from: number; to: number }
   size: 'auto' | 'custom'
-  customSize: { width: number; height: number }
+  customSize: Size
   duration: 'auto' | 'custom'
   customDuration: number
 }

--- a/src/composables/storage.ts
+++ b/src/composables/storage.ts
@@ -443,7 +443,7 @@ export function useStorage() {
     const graph = graphStore.lastSelectedGraph.value
     const duration =
       animSettings.duration === 'auto'
-        ? (frameCount * 100) / 6 // Reduce round-off error, e.g. frameCount * (1000 / 60)
+        ? ((frameCount - 1) * 100) / 6 // Reduce round-off error, e.g. X * (1000 / 60)
         : animSettings.customDuration
 
     const svgElm = serializeToAnimatedSvg(

--- a/src/composables/storage.ts
+++ b/src/composables/storage.ts
@@ -453,7 +453,8 @@ export function useStorage() {
       duration,
       'infinite',
       animSettings.interpolation,
-      animSettings.fps / 60
+      animSettings.fps / 60,
+      animSettings.size === 'custom' ? animSettings.customSize : undefined
     )
 
     if (animSettings.size === 'custom') {

--- a/src/utils/svgMaker.ts
+++ b/src/utils/svgMaker.ts
@@ -18,6 +18,7 @@ Copyright (C) 2021, Tomoya Komiyama.
 */
 
 import { affineToTransform } from 'okageo'
+import { Size } from 'okanvas'
 import { ElementNode, ElementNodeAttributes, IdMap } from '/@/models'
 import {
   mapFilter,
@@ -121,7 +122,8 @@ export function serializeToAnimatedSvg(
   duration: number,
   iteration: number | 'infinite' = 'infinite',
   interplocation: 'discrete' | 'linear' = 'discrete',
-  quolity = 1
+  quolity = 1,
+  size?: Size
 ): SVGElement {
   const thinnedOutAttributesMapPerFrame = thinOutList(
     attributesMapPerFrame,
@@ -129,11 +131,12 @@ export function serializeToAnimatedSvg(
     true
   )
 
-  const adjustedSvgRoot = immigrateViewBox(svgRoot)
+  const adjustedSvgRoot = immigrateViewBox(svgRoot, size)
   const adjustedAttributesMapPerFrame: IdMap<ElementNodeAttributes>[] =
     immigrateViewBoxPerFrame(
       adjustedSvgRoot.id,
-      thinnedOutAttributesMapPerFrame
+      thinnedOutAttributesMapPerFrame,
+      size
     )
 
   const allElements = flatElementTree([adjustedSvgRoot])
@@ -239,10 +242,10 @@ export function serializeToAnimatedSvg(
  * Translate `viewBox` of <svg> to `transform` of <g> in order to use CSS animation
  * => <g> element is inserted between <svg> and its children
  */
-function immigrateViewBox(svgRoot: ElementNode): ElementNode {
+function immigrateViewBox(svgRoot: ElementNode, size?: Size): ElementNode {
   return {
     ...svgRoot,
-    attributes: resetSvgViewBoxAttributes(svgRoot.attributes),
+    attributes: resetSvgViewBoxAttributes(svgRoot.attributes, size),
     children: [
       {
         id: VIEWBOX_G_ID,
@@ -259,14 +262,15 @@ function immigrateViewBox(svgRoot: ElementNode): ElementNode {
  */
 function immigrateViewBoxPerFrame(
   svgId: string,
-  attributesMapPerFrame: IdMap<ElementNodeAttributes>[]
+  attributesMapPerFrame: IdMap<ElementNodeAttributes>[],
+  size?: Size
 ) {
   return attributesMapPerFrame.map((attrsMap) => {
     return {
       ...attrsMap,
-      [svgId]: resetSvgViewBoxAttributes(attrsMap[svgId]),
+      [svgId]: resetSvgViewBoxAttributes(attrsMap[svgId], size),
       [VIEWBOX_G_ID]: {
-        transform: createTransformFromViewbox(attrsMap[svgId]?.viewBox),
+        transform: createTransformFromViewbox(attrsMap[svgId]?.viewBox, size),
       } as ElementNodeAttributes,
     }
   })
@@ -275,26 +279,30 @@ function immigrateViewBoxPerFrame(
 const BASE_VIEW_SIZE = 100
 
 function resetSvgViewBoxAttributes(
-  attrs: ElementNodeAttributes
+  attrs: ElementNodeAttributes,
+  size: Size = { width: BASE_VIEW_SIZE, height: BASE_VIEW_SIZE }
 ): ElementNodeAttributes {
   const svgAttrs = { ...attrs }
-  svgAttrs.viewBox = `0 0 ${BASE_VIEW_SIZE} ${BASE_VIEW_SIZE}`
+  svgAttrs.viewBox = `0 0 ${size.width} ${size.height}`
   // Original aspect ratio cannot be kept by viewBox transforming
   delete svgAttrs.width
   delete svgAttrs.height
   return svgAttrs
 }
 
-function createTransformFromViewbox(viewBoxStr: string) {
+function createTransformFromViewbox(
+  viewBoxStr: string,
+  size: Size = { width: BASE_VIEW_SIZE, height: BASE_VIEW_SIZE }
+) {
   const viewBox = parseViewBoxFromStr(viewBoxStr)
   if (!viewBox) return ''
 
-  const scaleX = BASE_VIEW_SIZE / viewBox.width
-  const scaleY = BASE_VIEW_SIZE / viewBox.height
+  const scaleX = size.width / viewBox.width
+  const scaleY = size.height / viewBox.height
 
   const minScale = Math.min(scaleX, scaleY)
-  const paddingX = (BASE_VIEW_SIZE - viewBox.width * minScale) / 2
-  const paddingY = (BASE_VIEW_SIZE - viewBox.height * minScale) / 2
+  const paddingX = (size.width - viewBox.width * minScale) / 2
+  const paddingY = (size.height - viewBox.height * minScale) / 2
 
   return affineToTransform([
     minScale,

--- a/src/utils/svgMaker.ts
+++ b/src/utils/svgMaker.ts
@@ -17,7 +17,6 @@ along with Blendic SVG.  If not, see <https://www.gnu.org/licenses/>.
 Copyright (C) 2021, Tomoya Komiyama.
 */
 
-import { affineToTransform } from 'okageo'
 import { Size } from 'okanvas'
 import { ElementNode, ElementNodeAttributes, IdMap } from '/@/models'
 import {
@@ -33,6 +32,7 @@ import {
 } from '/@/utils/elements'
 import { logRound } from '/@/utils/geometry'
 import { normalizeAttributes } from '/@/utils/helpers'
+import { affineToTransformTruncated } from '/@/utils/poseResolver'
 
 export function makeSvg(
   svgNode: ElementNode,
@@ -304,7 +304,7 @@ function createTransformFromViewbox(
   const paddingX = (size.width - viewBox.width * minScale) / 2
   const paddingY = (size.height - viewBox.height * minScale) / 2
 
-  return affineToTransform([
+  return affineToTransformTruncated([
     minScale,
     0,
     0,


### PR DESCRIPTION
fix #658

[fix: Truncate virtual viewBox matrix values](https://github.com/miyanokomiya/blendic-svg/commit/e40e5fc5f1b57e724d4e53e0e6cf09689149f8e1)
[fix: Inaccurate animation duration](https://github.com/miyanokomiya/blendic-svg/commit/3495fa4402672f8ec996baa7dbb393a3d067565a)