### PR TITLE
feat: Expand tree node when it's selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Scroll to the selected tree node automatically
+- Expand tree node when it's selected
 
 ### Refactor
 - Remove SASS dependency

--- a/spec/composables/treeContext.spec.ts
+++ b/spec/composables/treeContext.spec.ts
@@ -1,0 +1,85 @@
+/*
+This file is part of Blendic SVG.
+
+Blendic SVG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Blendic SVG is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Blendic SVG.  If not, see <https://www.gnu.org/licenses/>.
+
+Copyright (C) 2022, Tomoya Komiyama.
+*/
+
+import {
+  clearClosedState,
+  injectTreeContext,
+  provideTreeContext,
+} from '/@/composables/treeContext'
+
+describe('src/composables/treeContext.ts', () => {
+  beforeEach(() => {
+    clearClosedState()
+  })
+
+  describe('provideTreeContext', () => {
+    function prepare() {
+      const provided: { [key: string]: any } = {}
+      const provide = (key: string, value: any) => (provided[key] = value)
+      return { provide, provided }
+    }
+
+    describe('setClosed', () => {
+      it('should set new value', () => {
+        const { provide, provided } = prepare()
+        provideTreeContext('test', { provide })
+        expect(provided.getClosedMap()).toEqual({})
+        provided.setClosed('a', true)
+        expect(provided.getClosedMap()).toEqual({ a: true })
+        provided.setClosed('b', true)
+        expect(provided.getClosedMap()).toEqual({ a: true, b: true })
+        provided.setClosed('a', false)
+        expect(provided.getClosedMap()).toEqual({ b: true })
+      })
+
+      it('should share the state among the key', () => {
+        const p1 = prepare()
+        const p2 = prepare()
+        const p3 = prepare()
+        provideTreeContext('same', { provide: p1.provide })
+        p1.provided.setClosed('a', true)
+        provideTreeContext('same', { provide: p2.provide })
+        provideTreeContext('different', { provide: p3.provide })
+        expect(p1.provided.getClosedMap()).toEqual({ a: true })
+        expect(p2.provided.getClosedMap()).toEqual({ a: true })
+        expect(p3.provided.getClosedMap()).toEqual({})
+      })
+    })
+  })
+
+  describe('injectTreeContext', () => {
+    function prepare() {
+      const injected: { [key: string]: any } = {}
+      const inject: any = (key: string, value: any) => (injected[key] = value)
+      return { inject, injected }
+    }
+
+    it('should inject the context', () => {
+      const { inject, injected } = prepare()
+      injectTreeContext(inject)
+      expect(Object.keys(injected).length).toBe(6)
+      expect(injected).toHaveProperty('getSelectedMap')
+      expect(injected).toHaveProperty('getEditable')
+      expect(injected).toHaveProperty('updateName')
+      expect(injected).toHaveProperty('onClickElement')
+      expect(injected).toHaveProperty('getClosedMap')
+      expect(injected).toHaveProperty('setClosed')
+    })
+  })
+})

--- a/src/components/atoms/TreeContainer.vue
+++ b/src/components/atoms/TreeContainer.vue
@@ -24,17 +24,18 @@ Copyright (C) 2022, Tomoya Komiyama.
 </template>
 
 <script lang="ts">
-import { ref, watchEffect } from 'vue'
+import { nextTick, ref, watchEffect } from 'vue'
 </script>
 
 <script setup lang="ts">
 const props = defineProps<{ scrollTarget?: string }>()
 
 const scrollContainer = ref<HTMLElement>()
-watchEffect(() => {
+watchEffect(async () => {
   if (props.scrollTarget && scrollContainer.value) {
+    await nextTick()
     scrollContainer.value
-      .querySelector(`[data-scroll_anchor="${props.scrollTarget}"]`)
+      ?.querySelector(`[data-scroll_anchor="${props.scrollTarget}"]`)
       ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
   }
 })

--- a/src/components/panelContents/ArmatureTreePanel.vue
+++ b/src/components/panelContents/ArmatureTreePanel.vue
@@ -82,7 +82,7 @@ function updateName(id: string, name: string) {
   }
 }
 
-provideTreeContext({
+provideTreeContext('armature', {
   onClickElement,
   getSelectedMap: () => mapReduce(store.selectedBones.value, () => true),
   getEditable: () => true,

--- a/src/components/panelContents/ElementTreePanel.vue
+++ b/src/components/panelContents/ElementTreePanel.vue
@@ -50,7 +50,7 @@ const lastselectedId = computed(() => {
   return elementStore.lastSelectedElementId.value
 })
 
-provideTreeContext({
+provideTreeContext('element', {
   onClickElement: elementStore.selectElement,
   getSelectedMap: () => elementStore.selectedElements.value,
 })


### PR DESCRIPTION
- fix #726
- When two panels exist in the window, only one of them can be scrolled automatically -- It's presumably because of browser's limitation
- Keep closed state as much as possible