### PR TITLE
fix: Text dragging didn't work because of "preventDefault" in global …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fix: Text dragging didn't work because of "preventDefault" in global "mousemove" handlers
 
 ## [0.18.2] - 2024-01-23
 ### Added

--- a/src/components/atoms/ResizableH.vue
+++ b/src/components/atoms/ResizableH.vue
@@ -104,8 +104,7 @@ const throttleDrag = useThrottle(onDrag, 1000 / 60, true)
 
 const drag = useDrag(throttleDrag)
 useGlobalMousemove((e) => {
-  e.preventDefault()
-  drag.onMove(e)
+  drag.onMove(e as any)
 })
 useGlobalMouseup(() => {
   resizableStorage.save(rate.value)

--- a/src/components/atoms/ResizableV.vue
+++ b/src/components/atoms/ResizableV.vue
@@ -94,8 +94,7 @@ const throttleDrag = useThrottle(onDrag, 1000 / 60, true)
 
 const drag = useDrag(throttleDrag)
 useGlobalMousemove((e) => {
-  e.preventDefault()
-  drag.onMove(e)
+  drag.onMove(e as any)
 })
 useGlobalMouseup(() => {
   resizableStorage.save(rate.value)

--- a/src/composables/window.ts
+++ b/src/composables/window.ts
@@ -54,7 +54,12 @@ export function useGlobalClick(fn: (e: MouseEvent) => void, capture = false) {
   })
 }
 
-export function useGlobalMousemove(fn: (e: MouseEvent) => void) {
+/**
+ * Don't call "preventDefault" or anything related to the event can be broken.
+ */
+export function useGlobalMousemove(
+  fn: (e: Omit<MouseEvent, 'preventDefault'>) => void
+) {
   onMounted(() => {
     window.addEventListener('mousemove', fn)
   })


### PR DESCRIPTION
…"mousemove" handlers

- Probably, there was no critical reason for calling "preventDefault"